### PR TITLE
Added a today at midnight fucntion, however

### DIFF
--- a/src/clj_time/core.clj
+++ b/src/clj_time/core.clj
@@ -77,6 +77,10 @@
   "Returns a DateTime for the current instant in the UTC time zone."
   (DateTime. #^DateTimeZone utc))
 
+(defn today-at-midnight []
+  "Returns a DateMidnight for today at midnight."
+  (DateMidnight.))
+
 (defn epoch []
   "Returns a DateTime for the begining of the Unix epoch in the UTC time zone."
   (DateTime. (long 0) #^DateTimeZone utc))

--- a/test/clj_time/core_test.clj
+++ b/test/clj_time/core_test.clj
@@ -6,6 +6,9 @@
 (deftest test-now
   (is (<= 2010 (year (now)))))
 
+(deftest test-today-at-midnight
+  (is (<= 2010 (year (today-at-midnight)))))
+
 (deftest test-epoch
   (let [e (epoch)]
     (is (= 1970 (year e)))


### PR DESCRIPTION
I followed the original libraries pattern for testing it, which could be improved upon.

If you don't mind I can use a date-testing util to test it, with the time fixed at a given time:
https://github.com/AlexBaranosky/Utilize/blob/master/src/utilize/testutils.clj

It would look something like this (but using today-at-midnight:
https://github.com/AlexBaranosky/Utilize/blob/master/test/utilize/testutils_test.clj

I didn't want to add another dependency to clj-time without asking first.

Another option is to just copy and paste it in, which I'd avoid, but its all up to you :)

I could also write similar test for `now`.
