### PR TITLE
use lein-multi to test for compatibility against multiple clojure versions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,6 @@
-(defproject clj-time "0.3.4"
+(defproject clj-time "0.3.5-SNAPSHOT"
   :description "A date and time library for Clojure, wrapping Joda Time."
   :dev-dependencies [[utilize "0.1.2"]]
-  :dependencies [[org.clojure/clojure "1.2.1"]
-                 [joda-time "2.0"]])
+  :dependencies [[joda-time "2.0"]]
+  :multi-deps {"1.3" [[org.clojure/clojure "1.3.0"]]
+               "1.2" [[org.clojure/clojure "1.2.1"]]})


### PR DESCRIPTION
I wasn't sure if `clj-time` was 1.3.0 compat based off of the project file (since it still lists 1.2 as the dep) so I verified with lein-multi.  Using lein-mutil will help you test against different versions of clojure and at the very least lets people know what versions are supported.

To use run `lein plugin install lein-multi 1.1.0` and then `lein multi test`.
