### PR TITLE
java.sql.Date handling for coerce

### DIFF
--- a/src/clj_time/coerce.clj
+++ b/src/clj_time/coerce.clj
@@ -38,6 +38,12 @@
   [#^Date date]
   (from-long (.getTime date)))
 
+(defn from-sql-date
+  "Returns a DateTime instance in the UTC time zone corresponding to the given
+   java.sql.Date object."
+  [#^java.sql.Date sql-date]
+  (from-long (.getTime sql-date)))
+
 (defn to-long
   "Convert `obj` to the number of milliseconds after the Unix epoch."
   [obj]
@@ -49,6 +55,12 @@
   [obj]
   (if-let [dt (to-date-time obj)]
     (Date. (.getMillis dt))))
+
+(defn to-sql-date
+  "Convert `obj` to a java.sql.Date instance."
+  [obj]
+  (if-let [dt (to-date-time obj)]
+    (java.sql.Date. (.getMillis dt))))
 
 (defn to-string
   "Returns a string representation of obj in UTC time-zone
@@ -71,6 +83,10 @@
   Date
   (to-date-time [date]
     (from-date date))
+
+  java.sql.Date
+  (to-date-time [sql-date]
+    (from-sql-date sql-date))
 
   DateTime
   (to-date-time [date-time]

--- a/test/clj_time/coerce_test.clj
+++ b/test/clj_time/coerce_test.clj
@@ -10,6 +10,12 @@
     (is (instance? Date d))
     (is (= dt (from-date d)))))
 
+(deftest test-from-sql-date
+  (let [dt (from-long 893462400000)
+        d  (to-sql-date dt)]
+    (is (instance? java.sql.Date d))
+    (is (= dt (from-sql-date d)))))
+
 (deftest test-from-long
   (is (= (date-time 1998 4 25) (from-long 893462400000))))
 
@@ -23,10 +29,23 @@
   (is (nil? (to-date "x")))
   (is (= (Date. 893462400000) (to-date (date-time 1998 4 25))))
   (is (= (Date. 893462400000) (to-date (Date. 893462400000))))
+  (is (= (Date. 893462400000) (to-date (java.sql.Date. 893462400000))))
   (is (= (Date. (long 0)) (to-date 0)))
   (is (= (Date. 893462400000) (to-date 893462400000)))
   (is (= (Date. 893462400000) (to-date (Timestamp. 893462400000))))
   (is (= (Date. 893462400000) (to-date "1998-04-25T00:00:00.000Z"))))
+
+(deftest test-to-sql-date
+  (is (nil? (to-sql-date nil)))
+  (is (nil? (to-sql-date "")))
+  (is (nil? (to-sql-date "x")))
+  (is (= (java.sql.Date. 893462400000) (to-sql-date (date-time 1998 4 25))))
+  (is (= (java.sql.Date. 893462400000) (to-sql-date (Date. 893462400000))))
+  (is (= (java.sql.Date. 893462400000) (to-sql-date (java.sql.Date. 893462400000))))
+  (is (= (java.sql.Date. (long 0)) (to-date 0)))
+  (is (= (java.sql.Date. 893462400000) (to-sql-date 893462400000)))
+  (is (= (java.sql.Date. 893462400000) (to-sql-date (Timestamp. 893462400000))))
+  (is (= (java.sql.Date. 893462400000) (to-sql-date "1998-04-25T00:00:00.000Z"))))
 
 (deftest test-to-date-time
   (is (nil? (to-date-time nil)))
@@ -34,6 +53,7 @@
   (is (nil? (to-date-time "x")))
   (is (= (date-time 1998 4 25) (to-date-time (date-time 1998 4 25))))
   (is (= (date-time 1998 4 25) (to-date-time (Date. 893462400000))))
+  (is (= (date-time 1998 4 25) (to-date-time (java.sql.Date. 893462400000))))
   (is (= (date-time 1970 1 1) (to-date-time 0)))
   (is (= (date-time 1998 4 25) (to-date-time 893462400000)))
   (is (= (date-time 1998 4 25) (to-date-time (Timestamp. 893462400000))))
@@ -45,6 +65,7 @@
   (is (nil? (to-long "x")))
   (is (= 893462400000 (to-long (date-time 1998 4 25))))
   (is (= 893462400000 (to-long (Date. 893462400000))))
+  (is (= 893462400000 (to-long (java.sql.Date. 893462400000))))
   (is (= (long 0) (to-long 0)))
   (is (= 893462400000 (to-long 893462400000)))
   (is (= 893462400000 (to-long (Timestamp. 893462400000))))
@@ -56,6 +77,7 @@
   (is (nil? (to-string "x")))
   (is (= "1998-04-25T00:00:00.000Z" (to-string (date-time 1998 4 25))))
   (is (= "1998-04-25T00:00:00.000Z" (to-string (Date. 893462400000))))
+  (is (= "1998-04-25T00:00:00.000Z" (to-string (java.sql.Date. 893462400000))))
   (is (= "1970-01-01T00:00:00.000Z" (to-string 0)))
   (is (= "1998-04-25T00:00:00.000Z" (to-string 893462400000)))
   (is (= "1998-04-25T00:00:00.000Z" (to-string (Timestamp. 893462400000))))
@@ -67,6 +89,7 @@
   (is (nil? (to-timestamp "x")))
   (is (= (Timestamp. 893462400000) (to-timestamp (date-time 1998 4 25))))
   (is (= (Timestamp. 893462400000) (to-timestamp (Date. 893462400000))))
+  (is (= (Timestamp. 893462400000) (to-timestamp (java.sql.Date. 893462400000))))
   (is (= (Timestamp. (long 0)) (to-timestamp 0)))
   (is (= (Timestamp. 893462400000) (to-timestamp 893462400000)))
   (is (= (Timestamp. 893462400000) (to-timestamp (Timestamp. 893462400000))))


### PR DESCRIPTION
Hi, I've been playing around with `java.sql.Date`s recently :-( and so I wanted to add `java.sql.Date` handling to `coerce`. Impl is a copy of `java.util.Date`'s.
