### PR TITLE
Upgrade to JodaTime 2.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;; common dependencies:
-(def deps '[[joda-time "2.0"]])
+(def deps '[[joda-time "2.1"]])
 
 ;; project definition with additional dependencies:
 (defproject clj-time "0.4.2-SNAPSHOT"


### PR DESCRIPTION
No test suite failures, no test suite failures for several projects of mine that use clj-time. [JodaTime release notes](https://github.com/JodaOrg/joda-time/blob/master/RELEASE-NOTES.txt) also mention only one possible compatibility problem vast majority of people are unlikely to encounter.
