### PR TITLE
format-local-time returns nil on nil date-time obj

### DIFF
--- a/src/clj_time/local.clj
+++ b/src/clj_time/local.clj
@@ -97,5 +97,5 @@
 (defn format-local-time [obj format-key]
   "Format obj as local time using the local formatter corresponding
    to format-key."
-  (when-let [fmt (format-key *local-formatters*)]
+  (when-let [fmt (and obj (format-key *local-formatters*))]
     (fmt/unparse fmt (to-local-date-time obj))))

--- a/test/clj_time/local_test.clj
+++ b/test/clj_time/local_test.clj
@@ -24,6 +24,8 @@
   (is (= (time/from-time-zone (time/date-time 1998 4 25) (time/default-time-zone)) (to-local-date-time "1998-04-25T00:00:00.000"))))
 
 (deftest test-format-local-time
+  (is (nil? (format-local-time nil :basic-date-time)))
+  (is (nil? (format-local-time (local-now) ::bad-formatter)))
   (is (= (fmt/unparse (ISODateTimeFormat/basicDateTime) (time/from-time-zone (time/date-time 1998 4 25) (time/default-time-zone)))
          (format-local-time (time/from-time-zone (time/date-time 1998 4 25) (time/default-time-zone)) :basic-date-time)))
   (is (= (fmt/unparse (ISODateTimeFormat/basicDateTime) (time/from-time-zone (time/date-time 1998 4 25) (time/default-time-zone)))


### PR DESCRIPTION
format-local-time returned current time on nil date-time obj:

(format-local-time nil :basic-date-time)
"20120610T093257.282-0400"

This pull request has it return nil to be consistent with (to-local-date-time nil) => nil.
