### PR TITLE
multi-parser does not use the given time zone for parsing

### DIFF
--- a/src/clj_time/format.clj
+++ b/src/clj_time/format.clj
@@ -48,7 +48,8 @@
           parsers (map #(.getParser #^DateTimeFormatter (formatter % dtz)) (cons fmts more))]
       (-> (DateTimeFormatterBuilder.)
         #^DateTimeFormatterBuilder (.append #^DateTimePrinter printer (into-array DateTimeParser parsers))
-        (.toFormatter)))))
+        (.toFormatter)
+        (.withZone dtz)))))
 
 (defn with-chronology
   "Return a copy of a formatter that uses the given Chronology."

--- a/test/clj_time/format_test.clj
+++ b/test/clj_time/format_test.clj
@@ -51,4 +51,8 @@
     (is (= "2012-02-01 22:15"
            (unparse fmt (parse fmt "2012/02/01@22:15"))))
     (is (= "2012-02-01 22:15"
-           (unparse fmt (parse fmt "201202012215"))))))
+           (unparse fmt (parse fmt "201202012215"))))
+    (is (= (date-time 2012 2 1 22 15)
+           (parse fmt "201202012215")))
+    (is (= "2012-02-01 22:15"
+           (unparse fmt (date-time 2012 2 1 22 15))))))


### PR DESCRIPTION
When using a formatter constructed with multiple formats, the parsed dates are in the local time zone instead of the given one. 

Fixed by applying (.withTimezone) to the resulting formatter. Also added a unit test that illustrates the problem.
