### PR TITLE
add codox support in dev profile

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-time/clj-time "0.4.5-SNAPSHOT" 
+(defproject clj-time/clj-time "0.4.5-SNAPSHOT"
   :description "A date and time library for Clojure, wrapping Joda Time."
   :url "https://github.com/seancorfield/clj-time"
   :mailing-list {:name "clj-time mailing list"
@@ -10,7 +10,8 @@
   :dependencies [[joda-time "2.1"] [org.clojure/clojure "1.3.0"]]
   :min-lein-version "2.0.0"
   :repositories [["sonatype-snapshots" "https://oss.sonatype.org/content/repositories/snapshots/"]]
-  :profiles {:dev {:dependencies [[utilize "0.1.2"]]}
+  :profiles {:dev {:dependencies [[utilize "0.1.2"]]
+                   :plugins [[codox "0.6.1"]]}
              :1.2 {:dependencies [[org.clojure/clojure "1.2.1"]]}
              :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.0-master-SNAPSHOT"]]}}


### PR DESCRIPTION
Hi Sean, 

It would be helpful to have a github hosted site (gh-pages branch with the generated files from "lein doc") with codox  documentation. It is better than no docs or having to read the tests/readme, it seems it would be relatively complete with almost no efforts (the docstring are good enough imho).
