### PR TITLE
format-local-time returns nil on bad date-time string

### DIFF
--- a/src/clj_time/local.clj
+++ b/src/clj_time/local.clj
@@ -97,5 +97,6 @@
 (defn format-local-time [obj format-key]
   "Format obj as local time using the local formatter corresponding
    to format-key."
-  (when-let [fmt (and obj (format-key *local-formatters*))]
-    (fmt/unparse fmt (to-local-date-time obj))))
+  (when-let [dt (to-local-date-time obj)]
+    (when-let [fmt (format-key *local-formatters*)]
+      (fmt/unparse fmt dt))))

--- a/test/clj_time/local_test.clj
+++ b/test/clj_time/local_test.clj
@@ -26,6 +26,8 @@
 (deftest test-format-local-time
   (is (nil? (format-local-time nil :basic-date-time)))
   (is (nil? (format-local-time (local-now) ::bad-formatter)))
+  (is (nil? (format-local-time "bad-time" :basic-date-time)))
+  (is (nil? (format-local-time "bad-time" ::bad-formatter)))
   (is (= (fmt/unparse (ISODateTimeFormat/basicDateTime) (time/from-time-zone (time/date-time 1998 4 25) (time/default-time-zone)))
          (format-local-time (time/from-time-zone (time/date-time 1998 4 25) (time/default-time-zone)) :basic-date-time)))
   (is (= (fmt/unparse (ISODateTimeFormat/basicDateTime) (time/from-time-zone (time/date-time 1998 4 25) (time/default-time-zone)))


### PR DESCRIPTION
format-local-time returned current time on bad date-time string:

(format-local-time "aaa" :week-date-time)
"2012-W37-7T23:53:56.363-04:00"

This pull request has it return nil.
