### PR TITLE
change parse-local to call parse-local rather than parse when no format is given

### DIFF
--- a/src/clj_time/format.clj
+++ b/src/clj_time/format.clj
@@ -155,7 +155,7 @@
             :let [d (try (parse f s) (catch Exception _ nil))]
             :when d] d))))
 
-(defn  parse-local
+(defn parse-local
   "Returns a LocalDateTime instance obtained by parsing the
    given string according to the given formatter."
   ([#^DateTimeFormatter fmt #^String s]
@@ -163,7 +163,7 @@
   ([#^String s]
      (first
       (for [f (vals formatters)
-            :let [d (try (parse f s) (catch Exception _ nil))]
+            :let [d (try (parse-local f s) (catch Exception _ nil))]
             :when d] d))))
 
 (defn unparse

--- a/test/clj_time/format_test.clj
+++ b/test/clj_time/format_test.clj
@@ -16,6 +16,8 @@
            (parse-local fmt "20100311")))))
 
 (deftest test-parse
+  (is (= (date-time 2010 10 11)
+         (parse "2010-10-11T00:00:00")))
   (let [fmt (formatters :date)]
     (is (= (date-time 2010 3 11)
            (parse fmt "2010-03-11"))))
@@ -36,6 +38,8 @@
                     (date-time 2010 3 11 17 49 20 881))))))
 
 (deftest test-local-parse
+  (is (= (local-date-time 2010 10 11)
+         (parse-local "2010-10-11T00:00:00")))
   (let [fmt (formatters :date)]
     (is (= (local-date-time 2010 3 11)
            (parse-local fmt "2010-03-11"))))


### PR DESCRIPTION
...is given for #41
