### PR TITLE
Add support for Joda YearMonth

### DIFF
--- a/src/clj_time/coerce.clj
+++ b/src/clj_time/coerce.clj
@@ -10,7 +10,7 @@
   (:refer-clojure :exclude [extend])
   (:use clj-time.core)
   (:require [clj-time.format :as time-fmt])
-  (:import (org.joda.time DateTime DateTimeZone DateMidnight))
+  (:import (org.joda.time DateTime DateTimeZone DateMidnight YearMonth))
   (:import java.util.Date java.sql.Timestamp))
 
 (defprotocol ICoerce
@@ -96,6 +96,10 @@
   DateMidnight
   (to-date-time [date-midnight]
     (.toDateTime date-midnight))
+
+  YearMonth
+  (to-date-time [year-month]
+    (date-time (year year-month) (month year-month)))
 
   Integer
   (to-date-time [integer]

--- a/src/clj_time/core.clj
+++ b/src/clj_time/core.clj
@@ -82,7 +82,7 @@
    you need to print or parse date-times, see clj-time.format. If you need to
    ceorce date-times to or from other types, see clj-time.coerce."
   (:refer-clojure :exclude [extend])
-  (:import (org.joda.time ReadablePartial ReadableDateTime ReadableInstant ReadablePeriod DateTime DateMidnight DateTimeZone Period PeriodType Interval Years Months Weeks Days Hours Minutes Seconds LocalDateTime)))
+  (:import (org.joda.time ReadablePartial ReadableDateTime ReadableInstant ReadablePeriod DateTime DateMidnight YearMonth DateTimeZone Period PeriodType Interval Years Months Weeks Days Hours Minutes Seconds LocalDateTime)))
 
 (defprotocol DateTimeProtocol
   "Interface for various date time functions"
@@ -138,6 +138,14 @@
   (minute [this] (.getMinuteOfHour this))
   (sec [this] (.getSecondOfMinute this))
   (milli [this] (.getMillisOfSecond this))
+  (after? [this #^ReadablePartial that] (.isAfter this that))
+  (before? [this #^ReadablePartial that] (.isBefore this that))
+  (plus- [this #^ReadablePeriod period] (.plus this period))
+  (minus- [this #^ReadablePeriod period] (.minus this period))
+
+  org.joda.time.YearMonth
+  (year [this] (.getYear this))
+  (month [this] (.getMonthOfYear this))
   (after? [this #^ReadablePartial that] (.isAfter this that))
   (before? [this #^ReadablePartial that] (.isBefore this that))
   (plus- [this #^ReadablePeriod period] (.plus this period))
@@ -216,6 +224,15 @@
   ([#^Integer year #^Integer month #^Integer day #^Integer hour
     #^Integer minute #^Integer second #^Integer millis]
    (LocalDateTime. year month day hour minute second millis)))
+
+(defn #^org.joda.time.YearMonth year-month
+  "Constructs and returns a new YearMonth.
+   Specify the year and month of year. Month is 1-indexed and defaults
+   to January (1)."
+  ([year]
+     (year-month year 1))
+  ([#^Integer year #^Integer month]
+     (YearMonth. year month)))
 
 (defn time-zone-for-offset
   "Returns a DateTimeZone for the given offset, specified either in hours or

--- a/test/clj_time/coerce_test.clj
+++ b/test/clj_time/coerce_test.clj
@@ -23,6 +23,10 @@
   (is (= (from-string "1998-04-25T00:00:00.000Z")
          (date-time 1998 4 25))))
 
+(deftest test-from-year-month
+  (is (= (to-date-time (year-month 1998 4))
+         (date-time 1998 4))))
+
 (deftest test-to-date
   (is (nil? (to-date nil)))
   (is (nil? (to-date "")))

--- a/test/clj_time/core_test.clj
+++ b/test/clj_time/core_test.clj
@@ -71,6 +71,14 @@
     (is (= 2    (sec    d)))
     (is (= 1    (milli  d)))))
 
+(deftest test-year-month-and-accessors
+  (let [d (year-month 1986)]
+    (is (= 1986 (year   d)))
+    (is (= 1    (month  d))))
+  (let [d (date-time 1986 10)]
+    (is (= 1986 (year   d)))
+    (is (= 10   (month  d)))))
+
 (deftest test-day-of-week
   (let [d (date-time 2010 4 24)]
     (is (= 6 (day-of-week d))))


### PR DESCRIPTION
Hi,

Thanks for an excellent library!

This pull request adds support for the Joda YearMonth type, useful for things only requiring a year and a month, for example credit card expiry dates.

Implements:
- a (useful) subset of the DateTimeProtocol for the YearMonth type
- coercion to DateTime, using date-time constructor fn
- construction by year-month function

Please let me know if this is not a good fit for the clj-time abstractions or if there is anything I can do to improve it.
