### PR TITLE
add ability to use within? function on LocalDates

### DIFF
--- a/src/clj_time/core.clj
+++ b/src/clj_time/core.clj
@@ -448,11 +448,18 @@
   (.getYears (.toPeriod in (years))))
 
 (defn within?
-  "Returns true if the given Interval contains the given ReadableDateTime. Note that
-   if the ReadableDateTime is exactly equal to the end of the interval, this function
-   returns false."
-  [#^Interval i #^ReadableDateTime dt]
-  (.contains i dt))
+  "With 2 arguments: Returns true if the given Interval contains the given
+   ReadableDateTime. Note that if the ReadableDateTime is exactly equal to the
+   end of the interval, this function returns false.
+   With 3 arguments: Returns true if the start ReadablePartial is
+   equal to or before and the end ReadablePartial is equal to or after the test
+   ReadablePartial."
+  ([#^Interval i #^ReadableDateTime dt]
+     (.contains i dt))
+  ([#^ReadablePartial start #^ReadablePartial end #^ReadablePartial test]
+     (or (= start test)
+         (= end test)
+         (and (before? start test) (after? end test)))))
 
 (defn overlaps?
   "Returns true of the two given Intervals overlap. Note that intervals that

--- a/test/clj_time/core_test.clj
+++ b/test/clj_time/core_test.clj
@@ -269,11 +269,18 @@
 (deftest test-within?
   (let [d1 (date-time 1985)
         d2 (date-time 1986)
-        d3 (date-time 1987)]
+        d3 (date-time 1987)
+        ld1 (local-date 2013 1 1)
+        ld2 (local-date 2013 2 28)
+        ld3 (local-date 2013 10 5)]
     (is (within? (interval d1 d3) d2))
     (is (not (within? (interval d1 d2) d3)))
     (is (not (within? (interval d1 d2) d2)))
-    (is (not (within? (interval d2 d3) d1)))))
+    (is (not (within? (interval d2 d3) d1)))
+    (is (within? ld1 ld3 ld2))
+    (is (not (within? ld1 ld2 ld3)))
+    (is (not (within? ld3 ld2 ld1)))
+    (is (not (within? ld2 ld3 ld1)))))
 
 (deftest test-overlaps?
   (let [d1 (date-time 1985)


### PR DESCRIPTION
LocalDates cannot be used to create Intervals in JodaTime, but it still makes sense to ask if a given LocalDate is within two other LocalDates. This adds a 3-arg version of within? that takes a start, end, and test ReadablePartial and returns true if test is within start and end.
