### PR TITLE
Add to-sql-time

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,9 @@ For example, to convert a Joda `DateTime` to and from a Java `long`:
 #<DateTime 1998-04-25T00:00:00.000Z>
 ```
 
-There are also conversions to and from `java.util.Date` (`to-date` and `from-date`), `java.sql.Date` (`to-sql-date` and `from-sql-date`) and several other types.
+There are also conversions to and from `java.util.Date` (`to-date` and
+`from-date`), `java.sql.Date` (`to-sql-date` and `from-sql-date`),
+`java.sql.Timestamp` (`to-sql-time` and `from-sql-time`) and several other types.
 
 ### clj-time.local
 

--- a/src/clj_time/coerce.clj
+++ b/src/clj_time/coerce.clj
@@ -45,6 +45,12 @@
   [#^java.sql.Date sql-date]
   (from-long (.getTime sql-date)))
 
+(defn from-sql-time
+  "Returns a DateTime instance in the UTC time zone corresponding to the given
+   java.sql.Timestamp object."
+  [#^java.sql.Timestamp sql-time]
+  (from-long (.getTime sql-time)))
+
 (defn to-long
   "Convert `obj` to the number of milliseconds after the Unix epoch."
   [obj]
@@ -100,6 +106,10 @@
   java.sql.Date
   (to-date-time [sql-date]
     (from-sql-date sql-date))
+
+  java.sql.Timestamp
+  (to-date-time [sql-time]
+    (from-sql-time sql-time))
 
   DateTime
   (to-date-time [date-time]

--- a/test/clj_time/coerce_test.clj
+++ b/test/clj_time/coerce_test.clj
@@ -16,6 +16,12 @@
     (is (instance? java.sql.Date d))
     (is (= dt (from-sql-date d)))))
 
+(deftest test-from-sql-time
+  (let [dt (from-long 893462400000)
+        d  (to-sql-time dt)]
+    (is (instance? java.sql.Timestamp d))
+    (is (= dt (from-sql-time d)))))
+
 (deftest test-from-long
   (is (= (date-time 1998 4 25) (from-long 893462400000))))
 
@@ -56,6 +62,19 @@
   (is (= (java.sql.Date. 893462400000) (to-sql-date 893462400000)))
   (is (= (java.sql.Date. 893462400000) (to-sql-date (Timestamp. 893462400000))))
   (is (= (java.sql.Date. 893462400000) (to-sql-date "1998-04-25T00:00:00.000Z"))))
+
+(deftest test-to-sql-time
+  (is (nil? (to-sql-time nil)))
+  (is (nil? (to-sql-time "")))
+  (is (nil? (to-sql-time "x")))
+  (is (= (java.sql.Timestamp. 893462400000) (to-sql-time (date-time 1998 4 25))))
+  (is (= (java.sql.Timestamp. 893462400000) (to-sql-time (date-midnight 1998 4 25))))
+  (is (= (java.sql.Timestamp. 893462400000) (to-sql-time (Date. 893462400000))))
+  (is (= (java.sql.Timestamp. 893462400000) (to-sql-time (java.sql.Timestamp. 893462400000))))
+  (is (= (java.sql.Timestamp. (long 0)) (to-sql-time 0)))
+  (is (= (java.sql.Timestamp. 893462400000) (to-sql-time 893462400000)))
+  (is (= (java.sql.Timestamp. 893462400000) (to-sql-time (Timestamp. 893462400000))))
+  (is (= (java.sql.Timestamp. 893462400000) (to-sql-time "1998-04-25T00:00:00.000Z"))))
 
 (deftest test-to-date-time
   (is (nil? (to-date-time nil)))


### PR DESCRIPTION
I couldn't find "to-sql-time" despite java.sql.Timestamp getting imported. I'd very much like to not having this floating around in my models.clj in future, so here you go.
