### PR TITLE
API Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ instances. Construct one using `interval`, then query them using `within?`,
 true
 ```
 
-The `in-secs` and `in-minutes` functions can be used to describe intervals in the corresponding temporal units:
+The `in-seconds` and `in-minutes` functions can be used to describe intervals in the corresponding temporal units:
 
 ``` clj
 => (in-minutes (interval (date-time 1986 10 2) (date-time 1986 10 14)))

--- a/src/clj_time/coerce.clj
+++ b/src/clj_time/coerce.clj
@@ -7,7 +7,7 @@
 
      => (from-long 893462400000)
      #<DateTime 1998-04-25T00:00:00.000Z>"
-  (:refer-clojure :exclude [extend])
+  (:refer-clojure :exclude [extend second])
   (:use clj-time.core)
   (:require [clj-time.format :as time-fmt])
   (:import (org.joda.time DateTime DateTimeZone DateMidnight YearMonth LocalDate))
@@ -56,6 +56,12 @@
   [obj]
   (if-let [dt (to-date-time obj)]
     (.getMillis dt)))
+
+(defn to-epoch
+  "Convert `obj` to Unix epoch."
+  [obj]
+  (let [millis (to-long obj)]
+    (and millis (/ millis 1000))))
 
 (defn to-date
   "Convert `obj` to a Java Date instance."

--- a/src/clj_time/core.clj
+++ b/src/clj_time/core.clj
@@ -20,7 +20,7 @@
 
    Get the current time with (now) and the start of the Unix epoch with (epoch).
 
-   Once you have a date-time, use accessors like hour and sec to access the
+   Once you have a date-time, use accessors like hour and second to access the
    corresponding fields:
 
      => (hour (date-time 1986 10 14 22))
@@ -72,7 +72,7 @@
                  (date-time 1987))
      true
 
-   To find the amount of time encompased by an interval, use in-secs and
+   To find the amount of time encompased by an interval, use in-seconds and
    in-minutes:
 
      => (in-minutes (interval (date-time 1986 10 2) (date-time 1986 10 14)))
@@ -81,12 +81,15 @@
    Note that all functions in this namespace work with Joda objects or ints. If
    you need to print or parse date-times, see clj-time.format. If you need to
    ceorce date-times to or from other types, see clj-time.coerce."
-  (:refer-clojure :exclude [extend])
+  (:refer-clojure :exclude [extend second])
   (:import (org.joda.time ReadablePartial ReadableDateTime ReadableInstant ReadablePeriod DateTime
                           DateMidnight YearMonth LocalDate DateTimeZone Period PeriodType Interval
                           Years Months Weeks Days Hours Minutes Seconds LocalDateTime MutableDateTime
                           DateTimeUtils)
            (org.joda.time.base BaseDateTime)))
+
+(defn deprecated [message]
+  (println "DEPRECATION WARNING: " message))
 
 (defprotocol DateTimeProtocol
   "Interface for various date time functions"
@@ -97,12 +100,14 @@
   (hour [this]   "Return the hour of day component of the given date/time. A time of 12:01am will have an hour component of 0.")
   (minute [this]   "Return the minute of hour component of the given date/time.")
   (sec [this]   "Return the second of minute component of the given date/time.")
+  (second [this]   "Return the second of minute component of the given date/time.")
   (milli [this]   "Return the millisecond of second component of the given date/time.")
   (after? [this that] "Returns true if ReadableDateTime 'this' is strictly after date/time 'that'.")
   (before? [this that] "Returns true if ReadableDateTime 'this' is strictly before date/time 'that'.")
   (plus- [this #^ReadablePeriod period]
     "Returns a new date/time corresponding to the given date/time moved forwards by the given Period(s).")
-  (minus- [this #^ReadablePeriod period]  "Returns a new date/time corresponding to the given date/time moved backwards by the given Period(s)."))
+  (minus- [this #^ReadablePeriod period]
+    "Returns a new date/time corresponding to the given date/time moved backwards by the given Period(s)."))
 
 (extend-protocol DateTimeProtocol
   org.joda.time.DateTime
@@ -112,7 +117,10 @@
   (day-of-week [this] (.getDayOfWeek this))
   (hour [this] (.getHourOfDay this))
   (minute [this] (.getMinuteOfHour this))
-  (sec [this] (.getSecondOfMinute this))
+  (sec [this]
+    (deprecated "sec is being deprecated in favor of second")
+    (.getSecondOfMinute this))
+  (second [this] (.getSecondOfMinute this))
   (milli [this] (.getMillisOfSecond this))
   (after? [this #^ReadableInstant that] (.isAfter this that))
   (before? [this #^ReadableInstant that] (.isBefore this that))
@@ -126,7 +134,10 @@
   (day-of-week [this] (.getDayOfWeek this))
   (hour [this] (.getHourOfDay this))
   (minute [this] (.getMinuteOfHour this))
-  (sec [this] (.getSecondOfMinute this))
+  (sec [this]
+    (deprecated "sec is being deprecated in favor of second")
+    (.getSecondOfMinute this))
+  (second [this] (.getSecondOfMinute this))
   (milli [this] (.getMillisOfSecond this))
   (after? [this #^ReadableInstant that] (.isAfter this that))
   (before? [this #^ReadableInstant that] (.isBefore this that))
@@ -140,7 +151,10 @@
   (day-of-week [this] (.getDayOfWeek this))
   (hour [this] (.getHourOfDay this))
   (minute [this] (.getMinuteOfHour this))
-  (sec [this] (.getSecondOfMinute this))
+  (sec [this]
+    (deprecated "sec is being deprecated in favor of second")
+    (.getSecondOfMinute this))
+  (second [this] (.getSecondOfMinute this))
   (milli [this] (.getMillisOfSecond this))
   (after? [this #^ReadablePartial that] (.isAfter this that))
   (before? [this #^ReadablePartial that] (.isBefore this that))
@@ -271,9 +285,10 @@
   ([hours minutes]
    (DateTimeZone/forOffsetHoursMinutes hours minutes)))
 
-(defn time-zone-for-id [#^String id]
+(defn time-zone-for-id
   "Returns a DateTimeZone for the given ID, which must be in long form, e.g.
    'America/Matamoros'."
+  [#^String id]
   (DateTimeZone/forID id))
 
 (defn default-time-zone
@@ -345,7 +360,7 @@
   ([#^Integer n]
      (Minutes/minutes n)))
 
-(defn secs
+(defn seconds
   "Given a number, returns a Period representing that many seconds.
    Without an argument, returns a PeriodType representing only seconds."
   ([]
@@ -367,7 +382,7 @@
   ([dt #^ReadablePeriod p]
      (plus- dt p))
   ([dt p & ps]
-     (reduce #(plus- %1 %2) (plus- dt p) ps)))
+     (reduce plus- (plus- dt p) ps)))
 
 (defn minus
   "Returns a new date/time object corresponding to the given date/time moved backwards by
@@ -375,7 +390,7 @@
   ([dt #^ReadablePeriod p]
    (minus- dt p))
   ([dt p & ps]
-     (reduce #(minus- %1 %2) (minus- dt p) ps)))
+     (reduce minus- (minus- dt p) ps)))
 
 (defn ago
   "Returns a DateTime a supplied period before the present.
@@ -411,15 +426,21 @@
   [#^Interval in & by]
   (.withEnd in (apply plus (end in) by)))
 
-(defn in-msecs
+(defn in-millis
   "Returns the number of milliseconds in the given Interval."
   [#^Interval in]
   (.toDurationMillis in))
 
-(defn in-secs
+(defn in-msecs
+  "DEPRECATED: Returns the number of milliseconds in the given Interval."
+  [#^Interval in]
+  (deprecated "DEPRECATED: use in-millis")
+  (in-millis in))
+
+(defn in-seconds
   "Returns the number of standard seconds in the given Interval."
   [#^Interval in]
-  (.getSeconds (.toPeriod in (secs))))
+  (.getSeconds (.toPeriod in (seconds))))
 
 (defn in-minutes
   "Returns the number of standard minutes in the given Interval."
@@ -514,7 +535,7 @@
   [val]
   (instance? Minutes val))
 
-(defn secs?
+(defn seconds?
   "Returns true if the given value is an instance of Seconds"
   [val]
   (instance? Seconds val))
@@ -534,7 +555,7 @@
   (^long [^DateTime dt]
          (number-of-days-in-the-month (.getYear dt) (.getMonthOfYear dt)))
   (^long [^long year ^long month]
-         (-> ^DateTime (last-day-of-the-month year month) .getDayOfMonth)))
+         (.getDayOfMonth ^DateTime (last-day-of-the-month year month))))
 
 (defn ^DateTime first-day-of-the-month
   ([^DateTime dt]
@@ -545,7 +566,7 @@
 
 (defn ^DateTime today-at
   ([^long hours ^long minutes ^long seconds ^long millis]
-     (let [^MutableDateTime mdt (-> ^DateTime (now) .toMutableDateTime)]
+     (let [^MutableDateTime mdt (.toMutableDateTime ^DateTime (now))]
        (.toDateTime (doto mdt
                       (.setHourOfDay      hours)
                       (.setMinuteOfHour   minutes)

--- a/src/clj_time/format.clj
+++ b/src/clj_time/format.clj
@@ -25,7 +25,7 @@
    instance in UTC. A formatter can be modified to different timezones, locales,
    etc with the functions with-zone, with-locale, with-chronology, and
    with-pivot-year."
-  (:refer-clojure :exclude [extend])
+  (:refer-clojure :exclude [extend second])
   (:use [clojure.set :only (difference)])
   (:use clj-time.core)
   (:import (java.util Locale)

--- a/test/clj_time/coerce_test.clj
+++ b/test/clj_time/coerce_test.clj
@@ -1,5 +1,5 @@
 (ns clj-time.coerce-test
-  (:refer-clojure :exclude [extend])
+  (:refer-clojure :exclude [extend second])
   (:use clojure.test)
   (:use (clj-time core coerce))
   (:import java.util.Date java.sql.Timestamp org.joda.time.LocalDate))
@@ -103,6 +103,20 @@
   (is (= 893462400000 (to-long 893462400000)))
   (is (= 893462400000 (to-long (Timestamp. 893462400000))))
   (is (= 893462400000 (to-long "1998-04-25T00:00:00.000Z"))))
+
+(deftest test-to-epoch
+  (is (nil? (to-epoch nil)))
+  (is (nil? (to-epoch "")))
+  (is (nil? (to-epoch "x")))
+  (is (= 893462400 (to-epoch (date-time 1998 4 25))))
+  (is (= 0 (to-epoch (date-midnight 1970))))
+  (is (= (to-epoch (date-time 1993 3 15)) (to-epoch (date-midnight 1993 3 15))))
+  (is (= 893462400 (to-epoch (Date. 893462400000))))
+  (is (= 893462400 (to-epoch (java.sql.Date. 893462400000))))
+  (is (= (long 0) (to-epoch 0)))
+  (is (= 893462400 (to-epoch 893462400000)))
+  (is (= 893462400 (to-epoch (Timestamp. 893462400000))))
+  (is (= 893462400 (to-epoch "1998-04-25T00:00:00.000Z"))))
 
 (deftest test-to-string
   (is (nil? (to-string nil)))

--- a/test/clj_time/core_test.clj
+++ b/test/clj_time/core_test.clj
@@ -1,5 +1,5 @@
 (ns clj-time.core-test
-  (:refer-clojure :exclude [extend])
+  (:refer-clojure :exclude [extend second])
   (:use clojure.test
         clj-time.core)
   (:import java.util.Date
@@ -18,7 +18,7 @@
 (deftest test-epoch
   (let [e (epoch)]
     (is (= 1970 (year e)))
-    (is (= 0 (sec e)))))
+    (is (= 0 (second e)))))
 
 (deftest test-date-time-and-accessors
   (let [d (date-time 1986)]
@@ -27,7 +27,7 @@
     (is (= 1    (day    d)))
     (is (= 0    (hour   d)))
     (is (= 0    (minute d)))
-    (is (= 0    (sec    d)))
+    (is (= 0    (second d)))
     (is (= 0    (milli  d))))
   (let [d (date-time 1986 10 14 4 3 2 1)]
     (is (= 1986 (year   d)))
@@ -35,7 +35,7 @@
     (is (= 14   (day    d)))
     (is (= 4    (hour   d)))
     (is (= 3    (minute d)))
-    (is (= 2    (sec    d)))
+    (is (= 2    (second d)))
     (is (= 1    (milli  d)))))
 
 (deftest test-date-midnight-and-accessors
@@ -45,7 +45,7 @@
     (is (= 1    (day    d)))
     (is (= 0    (hour   d)))
     (is (= 0    (minute d)))
-    (is (= 0    (sec    d)))
+    (is (= 0    (second    d)))
     (is (= 0    (milli  d))))
   (let [d (date-midnight 1986 10 14)]
     (is (= 1986 (year   d)))
@@ -53,7 +53,7 @@
     (is (= 14   (day    d)))
     (is (= 0    (hour   d)))
     (is (= 0    (minute d)))
-    (is (= 0    (sec    d)))
+    (is (= 0    (second d)))
     (is (= 0    (milli  d)))))
 
 (deftest test-local-date-time-and-accessors
@@ -63,7 +63,7 @@
     (is (= 1    (day    d)))
     (is (= 0    (hour   d)))
     (is (= 0    (minute d)))
-    (is (= 0    (sec    d)))
+    (is (= 0    (second d)))
     (is (= 0    (milli  d))))
   (let [d (date-time 1986 10 14 4 3 2 1)]
     (is (= 1986 (year   d)))
@@ -71,7 +71,7 @@
     (is (= 14   (day    d)))
     (is (= 4    (hour   d)))
     (is (= 3    (minute d)))
-    (is (= 2    (sec    d)))
+    (is (= 2    (second d)))
     (is (= 1    (milli  d)))))
 
 (deftest test-year-month-and-accessors
@@ -144,7 +144,7 @@
            (days 13)
            (hours 4)
            (minutes 3)
-           (secs 2)
+           (seconds 2)
            (millis 1))))
   (is (= (date-time 1986 1 8)
          (plus (date-time 1986 1 1) (weeks 1)))))
@@ -179,7 +179,7 @@
            (days 13)
            (hours 4)
            (minutes 3)
-           (secs 2)
+           (seconds 2)
            (millis 1))))
   (is (= (local-date-time 1986 1 8)
          (plus (local-date-time 1986 1 1) (weeks 1)))))
@@ -255,8 +255,8 @@
     (is (= 20      (in-days p)))
     (is (= 489     (in-hours p)))
     (is (= 29397   (in-minutes p)))
-    (is (= 1763822 (in-secs p)))
-    (is (= 1763822000 (in-msecs p)))))
+    (is (= 1763822 (in-seconds p)))
+    (is (= 1763822000 (in-millis p)))))
 
 (deftest test-interval-in-bigger
   (let [p (interval (date-time 1986 10 14 12 5 4) (date-time 1987 11 3  22 2 6))]
@@ -335,7 +335,7 @@
   (is (minutes? (minutes 2))))
 
 (deftest test-secs?
-  (is (secs? (secs 2))))
+  (is (seconds? (seconds 2))))
 
 (deftest mins-ago-test
   (is (= 5 (mins-ago (minus (now) (minutes 5))))))

--- a/test/clj_time/format_test.clj
+++ b/test/clj_time/format_test.clj
@@ -1,5 +1,5 @@
 (ns clj-time.format-test
-  (:refer-clojure :exclude [extend])
+  (:refer-clojure :exclude [extend second])
   (:use clojure.test
         (clj-time core format))
   (:import [org.joda.time DateTimeZone]

--- a/test/clj_time/predicates_test.clj
+++ b/test/clj_time/predicates_test.clj
@@ -1,5 +1,5 @@
 (ns clj-time.predicates-test
-  (:refer-clojure :exclude [extend])
+  (:refer-clojure :exclude [extend second])
   (:use clojure.test)
   (:use [clj-time core predicates]))
 


### PR DESCRIPTION
sec/second in-secs/in-seconds in-msecs / in-millis

Added to-epoch (unix seconds, which is standard in a lot of places) and did a little bit of stylistic cleanup.

(sec ...) protocol implementations have a deprecation message attached. if you prefer to log the deprecation by some means other than that a println, load the lib and logic you want, it's just a defn.

It should be noted that we were already using `refer-clojure :exclude` for extend.

Not sure why the PR picked up those older commits that had already been merged.
