### PR TITLE
deprecation and README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Less-significant fields can be omitted:
 
 Get the current time with `(now)` and the start of the Unix epoch with `(epoch)`.
 
-Once you have a date-time, use accessors like `hour` and `sec` to access the corresponding fields:
+Once you have a date-time, use accessors like `hour` and `second` to access the corresponding fields:
 
 ``` clj
 => (hour (date-time 1986 10 14 22))

--- a/src/clj_time/core.clj
+++ b/src/clj_time/core.clj
@@ -368,6 +368,13 @@
   ([#^Integer n]
      (Seconds/seconds n)))
 
+(defn secs
+  "DEPRECATED"
+  ([]
+     (seconds))
+  ([#^Integer n]
+     (seconds n)))
+
 (defn millis
   "Given a number, returns a Period representing that many milliseconds.
    Without an argument, returns a PeriodType representing only milliseconds."


### PR DESCRIPTION
What it says on the tin. missed `sec` in my initial grep :(

Deprecation should phase out on 0.6.0.
