### PR TITLE
added dependency badge;

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# `clj-time` <a href="http://travis-ci.org/#!/seancorfield/clj-time/builds"><img src="https://secure.travis-ci.org/seancorfield/clj-time.png" /></a>
+# `clj-time` <a href="http://travis-ci.org/#!/seancorfield/clj-time/builds"><img src="https://secure.travis-ci.org/seancorfield/clj-time.png" /></a> [![Dependency Status](https://www.versioneye.com/clojure/clj-time:clj-time/0.6.0/badge.png)](https://www.versioneye.com/clojure/clj-time:clj-time/0.6.0)
+
 
 A date and time library for Clojure, wrapping the [Joda Time](http://joda-time.sourceforge.net/) library.
 


### PR DESCRIPTION
Hi, 

i added dependency badge for clj-time: it's shows a state of dependencies for the latest release and users can find a additional metadata about clj-time after clicking on badge. 

I think for you as maintainer of the library,  you'll like our [references](https://www.versioneye.com/clojure/clj-time:clj-time/references) feature, which shows all registered clojure libraries using clj-time.
