### PR TITLE
Allow specifying timezone for today-at-midnight

### DIFF
--- a/src/clj_time/core.clj
+++ b/src/clj_time/core.clj
@@ -193,8 +193,10 @@
 
 (defn today-at-midnight
   "Returns a DateMidnight for today at midnight in the UTC time zone."
-  []
-  (DateMidnight. ^DateTimeZone utc))
+  ([]
+   (DateMidnight. ^DateTimeZone utc))
+  ([^DateTimeZone tz]
+   (DateMidnight. tz)))
 
 (defn epoch
   "Returns a DateTime for the begining of the Unix epoch in the UTC time zone."

--- a/test/clj_time/core_test.clj
+++ b/test/clj_time/core_test.clj
@@ -13,7 +13,10 @@
 (deftest test-today-at-midnight
   (is (= (date-midnight 2010 1 1)
          (do-at (date-midnight 2010 1 1)
-                (today-at-midnight)))))
+                (today-at-midnight))))
+  (let [midnight (do-at (date-time 2010 1 15 2)
+                        (today-at-midnight (time-zone-for-offset -3)))]
+    (is (= 14 (day midnight)))))
 
 (deftest test-epoch
   (let [e (epoch)]


### PR DESCRIPTION
Right now there's no easy way to specify midnight today in a given timezone through clj-time. The best that I can think of is to get today's date in that timezone using `(to-timezome (now) tz)` and construct date-midnight from the year-month-day components, which is fairly messy.

This patch exposes the timezone parameter in DateMidnight's constructor to make that much easier.
