### PR TITLE
README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,12 @@ With Maven:
 Please open issues against the [official clj-time repo on Github](https://github.com/clj-time/clj-time/issues).
 
 **Note: version 0.6.0 introduces a number of API changes to improve consistency.**
-The API now uses `second`, `seconds` and `millis` where it previously had `sec`, `secs` and `msecs`. The older API is still present but marked as deprecated (and calling deprecated functions will print a message to the console as well returning the result). The older API will be removed in version 0.7.0 so be prepared to update your code.
+The API now uses `second`, `seconds` and `millis` where it previously
+had `sec`, `secs` and `msecs`. The older API is still present but
+marked as deprecated (and calling deprecated functions will print a
+message to the console as well returning the result). The older API
+will be removed in version 0.7.0 so be prepared to update your code.
+
 
 ## Usage
 
@@ -48,53 +53,69 @@ The API now uses `second`, `seconds` and `millis` where it previously had `sec`,
 The main namespace for date-time operations in the `clj-time` library is `clj-time.core`.
 
 ``` clj
-=> (use 'clj-time.core)
+=> (require '[clj-time.core :as t])
 ``` 
 
-Create a DateTime instance with date-time, specifying the year, month, day, hour, minute, second, and millisecond:
+Create a DateTime instance with date-time, specifying the year, month,
+day, hour, minute, second, and millisecond:
+
 
 ``` clj
-=> (date-time 1986 10 14 4 3 27 456)
+=> (t/date-time 1986 10 14 4 3 27 456)
 #<DateTime 1986-10-14T04:03:27.456Z>
 ```
 
 Less-significant fields can be omitted:
 
 ``` clj
-=> (date-time 1986 10 14)
+=> (t/date-time 1986 10 14)
 #<DateTime 1986-10-14T00:00:00.000Z>
 ```
 
-Get the current time with `(now)` and the start of the Unix epoch with `(epoch)`.
+Get the current time with `now` and the start of the Unix epoch with
+`epoch`.
 
-Once you have a date-time, use accessors like `hour` and `second` to access the corresponding fields:
+Once you have a date-time, use accessors like `hour` and `second` to
+access the corresponding fields:
+
 
 ``` clj
-=> (hour (date-time 1986 10 14 22))
+=> (t/hour (date-time 1986 10 14 22))
 22
 ```
 
-The date-time constructor always returns times in the UTC time zone. If you want a time with the specified fields in a different time zone, use `from-time-zone`:
+The date-time constructor always returns times in the UTC time
+zone. If you want a time with the specified fields in a different time
+zone, use `from-time-zone`:
+
 
 ``` clj
-=> (from-time-zone (date-time 1986 10 22) (time-zone-for-offset -2))
+=> (t/from-time-zone (t/date-time 1986 10 22) (t/time-zone-for-offset -2))
 #<DateTime 1986-10-22T00:00:00.000-02:00>
 ```
 
-If on the other hand you want a given absolute instant in time in a different time zone, use `to-time-zone`:
+If on the other hand you want a given absolute instant in time in a
+different time zone, use `to-time-zone`:
+
 
 ``` clj
-=> (to-time-zone (date-time 1986 10 22) (time-zone-for-offset -2))
+=> (t/to-time-zone (t/date-time 1986 10 22) (t/time-zone-for-offset -2))
 #<DateTime 1986-10-21T22:00:00.000-02:00>
 ```
 
-In addition to `time-zone-for-offset`, you can use the `time-zone-for-id` and `default-time-zone` functions and the `utc` Var to construct or get `DateTimeZone` instances.
+In addition to `time-zone-for-offset`, you can use the
+`time-zone-for-id` and `default-time-zone` functions and the `utc` Var
+to construct or get `DateTimeZone` instances.
 
-If you only want a date with no time component, consider using the `local-date` and `today` functions.
-These return `LocalDate` instances that do not have time components (and thus don't suffer from timezone-related shifting).
+
+If you only want a date with no time component, consider using the
+`local-date` and `today` functions. These return `LocalDate` instances
+that do not have time components (and thus don't suffer from
+timezone-related shifting).
+
 
 ``` clj
-=> (local-date 2013 3 20)
+=> (t/local-date 2013 3 20)
 #<LocalDate 2013-03-20>
 ```
 
@@ -102,33 +123,46 @@ The functions `after?` and `before?` determine the relative position of two
 DateTime instances:
 
 ``` clj
-=> (after? (date-time 1986 10) (date-time 1986 9))
+=> (t/after? (t/date-time 1986 10) (t/date-time 1986 9))
 true
 ```
 
-Often you will want to find a date some amount of time from a given date. For
-example, to find the time 1 month and 3 weeks from a given date-time:
+Often you will want to find a date some amount of time from a given
+date. For example, to find the time 1 month and 3 weeks from a given
+date-time:
+
 
 ``` clj
 => (plus (date-time 1986 10 14) (months 1) (weeks 3))
 #<DateTime 1986-12-05T00:00:00.000Z>
 ```
 
-An `Interval` is used to represent the span of time between two `DateTime`
-instances. Construct one using `interval`, then query them using `within?`,
-`overlaps?`, and `abuts?`
+An `Interval` is used to represent the span of time between two
+`DateTime` instances. Construct one using `interval`, then query them
+using `within?`, `overlaps?`, and `abuts?`
 
 ``` clj
-=> (within? (interval (date-time 1986) (date-time 1990))
-            (date-time 1987))
+=> (t/within? (t/interval (t/date-time 1986) (t/date-time 1990))
+              (t/date-time 1987))
 true
 ```
 
-The `in-seconds` and `in-minutes` functions can be used to describe intervals in the corresponding temporal units:
+The `in-seconds` and `in-minutes` functions can be used to describe
+intervals in the corresponding temporal units:
 
 ``` clj
-=> (in-minutes (interval (date-time 1986 10 2) (date-time 1986 10 14)))
+=> (t/in-minutes (t/interval (t/date-time 1986 10 2) (t/date-time 1986 10 14)))
 17280
+```
+
+`today-at` returns a moment in time at the given hour,
+minute and second on the current date:
+
+``` clojure
+=> (t/today-at 12 00)
+#<DateTime 2013-03-29T12:00:00.000Z>
+=> (t/today-at 12 00 05)
+#<DateTime 2013-03-29T12:00:05.000Z>
 ```
 
 ### clj-time.format
@@ -136,23 +170,27 @@ The `in-seconds` and `in-minutes` functions can be used to describe intervals in
 If you need to parse or print date-times, use `clj-time.format`:
 
 ``` clj
-=> (use 'clj-time.format)
+=> (require '[clj-time.format :as f])
 ```
 
-Parsing and printing are controlled by formatters. You can either use one of the built in ISO8601 formatters or define your own, e.g.:
+Parsing and printing are controlled by formatters. You can either use
+one of the built in ISO8601 formatters or define your own, e.g.:
 
 ``` clj
-(def built-in-formatter (formatters :basic-date-time))
-(def custom-formatter (formatter "yyyyMMdd"))
+(def built-in-formatter (f/formatters :basic-date-time))
+(def custom-formatter (f/formatter "yyyyMMdd"))
 ```
 
-To see a list of available built-in formatters and an example of a date-time printed in their format:
+To see a list of available built-in formatters and an example of a
+date-time printed in their format:
+
 
 ``` clj
-=> (show-formatters)
+=> (f/show-formatters)
 ```
 
-Remember that `mm` is minutes, `MM` is months, `ss` is seconds and `SS` is milliseconds.
+Remember that `mm` is minutes, `MM` is months, `ss` is seconds and
+`SS` is milliseconds.
 
 Once you have a formatter, parsing and printing are strait-forward:
 
@@ -160,52 +198,46 @@ Once you have a formatter, parsing and printing are strait-forward:
 => (parse custom-formatter "20100311")
 #<DateTime 2010-03-11T00:00:00.000Z>
 
-=> (unparse custom-formatter (date-time 2010 10 3))
+=> (f/unparse custom-formatter (t/date-time 2010 10 3))
 "20101003"
 ```
 
-To parse dates in multiple formats and format dates in just one format, you can do this:
+To parse dates in multiple formats and format dates in just one
+format, you can do this:
+
 
 ``` clj
-=> (def multi-parser (formatter (default-time-zone) "YYYY-MM-dd" "YYYY/MM/dd"))
+=> (def multi-parser (f/formatter (t/default-time-zone) "YYYY-MM-dd" "YYYY/MM/dd"))
 
-=> (unparse multi-parser (parse multi-parser "2012-02-01"))
+=> (f/unparse multi-parser (f/parse multi-parser "2012-02-01"))
 "2012-02-01"
 
-=> (unparse multi-parser (parse multi-parser "2012/02/01"))
+=> (f/unparse multi-parser (f/parse multi-parser "2012/02/01"))
 "2012-02-01"
 ```
-
-`clj-time.core/today-at` returns a moment in time at the given hour, minute and second
-on the current date:
-
-``` clojure
-=> (today-at 12 00)
-#<DateTime 2013-03-29T12:00:00.000Z>
-=> (today-at 12 00 05)
-#<DateTime 2013-03-29T12:00:05.000Z>
-```
-
 
 ### clj-time.coerce
 
-The namespace `clj-time.coerce` contains utility functions for coercing Joda `DateTime` instances to and from various other types:
+The namespace `clj-time.coerce` contains utility functions for
+coercing Joda `DateTime` instances to and from various other types:
+
 
 ``` clj
-=> (use 'clj-time.coerce)
+=> (require '[clj-time.coerce :as c])
 ```
 
 For example, to convert a Joda `DateTime` to and from a Java `long`:
 
 ``` clj
-=> (to-long (date-time 1998 4 25))
+=> (c/to-long (t/date-time 1998 4 25))
 893462400000
 
-=> (from-long 893462400000)
+=> (c/from-long 893462400000)
 #<DateTime 1998-04-25T00:00:00.000Z>
 ```
 
-And by the magic of protocols you can pass in an isoformat string and get the unix epoch milliseconds:
+And by the magic of protocols you can pass in an isoformat string and
+get the unix epoch milliseconds:
 
 ``` clj
 => (to-long "2013-08-01")
@@ -214,42 +246,51 @@ And by the magic of protocols you can pass in an isoformat string and get the un
 
 There are also conversions to and from `java.util.Date` (`to-date` and
 `from-date`), `java.sql.Date` (`to-sql-date` and `from-sql-date`),
-`java.sql.Timestamp` (`to-sql-time` and `from-sql-time`) and several other types.
+`java.sql.Timestamp` (`to-sql-time` and `from-sql-time`) and several
+other types.
 
 ### clj-time.local
 
-The namespace `clj-time.local` contains functions for working with local time without having to shift to/from utc,
-the preferred time zone of clj-time.core.
+The namespace `clj-time.local` contains functions for working with
+local time without having to shift to/from utc, the preferred time
+zone of clj-time.core.
+
+``` clj
+=> (require '[clj-time.local :as l])
+```
 
 Get the current local time with
 
 ``` clj
-=> (local-now)
+=> (l/local-now)
 ```
 
 Get a local date-time instance retaining the time fields with
 
 ``` clj
-=> (to-local-date-time obj)
+=> (l/to-local-date-time obj)
 ```
 
-The following all return 1986-10-14 04:03:27.246 with the local time zone.
+The following all return 1986-10-14 04:03:27.246 with the local time
+zone.
 
 ``` clj
-(to-local-date-time (clj-time.core/date-time 1986 10 14 4 3 27 246))
-(to-local-date-time "1986-10-14T04:03:27.246")
-(to-local-date-time "1986-10-14T04:03:27.246Z")
+(l/to-local-date-time (clj-time.core/date-time 1986 10 14 4 3 27 246))
+(l/to-local-date-time "1986-10-14T04:03:27.246")
+(l/to-local-date-time "1986-10-14T04:03:27.246Z")
 ```
 
-The dynamic var \*local-formatters\* contains a map of local formatters for parsing and printing. It is initialized
-with all the formatters in clj-time.format localized.
+The dynamic var `*local-formatters*` contains a map of local
+formatters for parsing and printing. It is initialized with all the
+formatters in clj-time.format localized.
 
-to-local-date-time for strings uses \*local-formatters\* to parse.
+to-local-date-time for strings uses `*local-formatters*` to parse.
 
-Format an obj using a formatter in \*local-formatters\* corresponding to the format-key passed in with
+Format an obj using a formatter in `*local-formatters*` corresponding
+to the format-key passed in with
 
 ``` clj
-=> (format-local-time (local-now) :basic-date-time)
+=> (l/format-local-time (l/local-now) :basic-date-time)
 ```
 
 
@@ -259,12 +300,12 @@ Format an obj using a formatter in \*local-formatters\* corresponding to the for
 separated by a time period starting with the given point in time:
 
 ``` clojure
-(use 'clj-time.periodic)
-(use 'clj-time.core)
+(require '[clj-time.periodic :as p])
+(require '[clj-time.core :as t])
 
 ;; returns 10 instants starting with current time separated
 ;; by 12 hours
-(take 10 (periodic-seq (now) (hours 12)))
+(take 10 (p/periodic-seq (t/now) (t/hours 12)))
 ```
 
 ### clj-time.predicates
@@ -273,20 +314,26 @@ separated by a time period starting with the given point in time:
 check for common conditions. For instance:
 
 ```clojure
-(require '[clj-time.core :as time])
-(use 'clj-time.predicates)
+(require '[clj-time.core :as t])
+(require '[clj-time.predicates :as pr])
 
-(monday? (time/date-time 1999 9 9))
+(pr/monday? (t/date-time 1999 9 9))
+;; => false
 
-(january? (time/date-time 2011 1 1))
+(pr/january? (t/date-time 2011 1 1))
+;; => true
 
-(weekend? (time/date-time 2014 1 26))
+(pr/weekend? (t/date-time 2014 1 26))
+;; => true
 
-(weekday? (time/date-time 2014 1 26))
+(pr/weekday? (t/date-time 2014 1 26))
+;; => false
 
-(last-day-of-month? (time/date-time 2014 1 26))
+(pr/last-day-of-month? (t/date-time 2014 1 26))
+;; => false
 
-(first-day-of-month? (time/date-time 2014 1 26))
+(pr/first-day-of-month? (t/date-time 2014 1 26))
+;; => false
 ```
 
 ## Development


### PR DESCRIPTION
@seancorfield, @michaelklishin This patch is mainly for the `require` instead of `use` suggestion I mentioned on Twitter, but I made a few other small tweaks as well:
- Use (require '[x.y :as z]) instead of (use x)
- Move today-at example into clj-time.core section
- Break up long lines

I worked through all of the examples in the README as if I were new to this library _and_ Clojure. The examples with ns aliases aren't as pretty but I think demonstrating good practices outweighs aesthetics. Also, it's easier to follow in some areas where multiple namespaces are being used.

Looking forward to any feedback you guys might have.
