### PR TITLE
Support for org.joda.time.LocalTime (times without time zone and date).

### DIFF
--- a/src/clj_time/core.clj
+++ b/src/clj_time/core.clj
@@ -83,7 +83,7 @@
    ceorce date-times to or from other types, see clj-time.coerce."
   (:refer-clojure :exclude [extend second])
   (:import (org.joda.time ReadablePartial ReadableDateTime ReadableInstant ReadablePeriod DateTime
-                          DateMidnight YearMonth LocalDate DateTimeZone Period PeriodType Interval
+                          DateMidnight YearMonth LocalDate LocalTime DateTimeZone Period PeriodType Interval
                           Years Months Weeks Days Hours Minutes Seconds LocalDateTime MutableDateTime
                           DateTimeUtils)
            (org.joda.time.base BaseDateTime)))
@@ -180,7 +180,18 @@
   (after? [this ^ReadablePartial that] (.isAfter this that))
   (before? [this ^ReadablePartial that] (.isBefore this that))
   (plus- [this ^ReadablePeriod period] (.plus this period))
-  (minus- [this ^ReadablePeriod period] (.minus this period)))
+  (minus- [this ^ReadablePeriod period] (.minus this period))
+
+  org.joda.time.LocalTime
+  (hour [this] (.getHourOfDay this))
+  (minute [this] (.getMinuteOfHour this))
+  (second [this] (.getSecondOfMinute this))
+  (milli [this] (.getMillisOfSecond this))
+  (after? [this ^ReadablePartial that] (.isAfter this that))
+  (before? [this ^ReadablePartial that] (.isBefore this that))
+  (plus- [this ^ReadablePeriod period] (.plus this period))
+  (minus- [this ^ReadablePeriod period] (.minus this period))
+  )
 
 (def ^{:doc "DateTimeZone for UTC."}
       utc
@@ -190,6 +201,12 @@
   "Returns a DateTime for the current instant in the UTC time zone."
   []
   (DateTime. ^DateTimeZone utc))
+
+(defn time-now
+  "Returns a LocalTime for the current instant without date or time zone
+  using ISOChronology in the current time zone."
+  []
+  (LocalTime. ))
 
 (defn today-at-midnight
   "Returns a DateMidnight for today at midnight in the UTC time zone."
@@ -240,7 +257,7 @@
 
 (defn ^org.joda.time.LocalDateTime local-date-time
   "Constructs and returns a new LocalDateTime.
-   Specify the year, month of year, day of month, hour of day, minute if hour,
+   Specify the year, month of year, day of month, hour of day, minute of hour,
    second of minute, and millisecond of second. Note that month and day are
    1-indexed while hour, second, minute, and millis are 0-indexed.
    Any number of least-significant components can be ommited, in which case
@@ -275,6 +292,21 @@
    Specify the year, month, and day. Does not deal with timezones."
   [^Integer year ^Integer month ^Integer day]
   (LocalDate. year month day))
+
+(defn ^org.joda.time.LocalTime local-time
+  "Constructs and returns a new LocalTime.
+   Specify the hour of day, minute of hour, second of minute, and millisecond of second.
+   Any number of least-significant components can be ommited, in which case
+   they will default to 1 or 0 as appropriate."
+  ([hour]
+   (local-time hour 0 0 0))
+  ([hour minute]
+   (local-time hour minute 0 0))
+  ([hour minute second]
+   (local-time hour minute second 0))
+  ([^Integer hour ^Integer minute ^Integer second ^Integer millis]
+   (LocalTime. hour minute second millis))
+  )
 
 (defn ^org.joda.time.LocalDate today
   "Constructs and returns a new LocalDate representing today's date.

--- a/src/clj_time/format.clj
+++ b/src/clj_time/format.clj
@@ -30,7 +30,7 @@
   (:use clj-time.core)
   (:import (java.util Locale)
            (org.joda.time Chronology DateTime DateTimeZone Interval LocalDateTime
-                          Period PeriodType LocalDate)
+                          Period PeriodType LocalDate LocalTime)
            (org.joda.time.format DateTimeFormat DateTimeFormatter DateTimePrinter
                                  DateTimeFormatterBuilder DateTimeParser
                                  ISODateTimeFormat)))
@@ -179,6 +179,17 @@
             :let [d (try (parse-local-date f s) (catch Exception _ nil))]
             :when d] d))))
 
+(defn parse-local-time
+  "Returns a LocalTime instance obtained by parsing the
+  given string according to the given formatter."
+  ([^DateTimeFormatter fmt ^ String s]
+   (.parseLocalTime fmt s))
+   ([^String s]
+     (first
+      (for [f (vals formatters)
+            :let [d (try (parse-local-time f s) (catch Exception _ nil))]
+            :when d] d))))
+
 (defn unparse
   "Returns a string representing the given DateTime instance in UTC and in the
   form determined by the given formatter."
@@ -192,10 +203,17 @@
   (.print fmt dt))
 
 (defn unparse-local-date
-  "Returns a string representing the given LocalDate instance in  the form
+  "Returns a string representing the given LocalDate instance in the form
   determined by the given formatter."
   [^DateTimeFormatter fmt ^LocalDate ld]
   (.print fmt ld))
+
+(defn unparse-local-time
+  "Returns a string representing the given LocalTime instance in the form
+  determined by the given formatter."
+  [^DateTimeFormatter fmt ^LocalTime lt]
+  (.print fmt lt))
+
 
 (defn show-formatters
   "Shows how a given DateTime, or by default the current time, would be

--- a/test/clj_time/core_test.clj
+++ b/test/clj_time/core_test.clj
@@ -92,6 +92,14 @@
     (is (= 19   (day    d)))
     (is (= 2    (day-of-week d)))))
 
+(deftest test-local-time-and-accessors
+  (let [t (local-time 12 11 10 9)]
+    (is (= 12 (hour t)))
+    (is (= 11 (minute t)))
+    (is (= 10 (second t)))
+    (is (= 9 (milli t)))
+    ))
+
 (deftest test-today
   (is (= (local-date 2013 4 20) (do-at (from-time-zone (date-time 2013 4 20) (default-time-zone))
                                   (today)))))
@@ -319,6 +327,30 @@
     (is (not (within? ld1 ld2 ld3)))
     (is (not (within? ld3 ld2 ld1)))
     (is (not (within? ld2 ld3 ld1)))))
+
+(deftest test-time-after?
+  (let [t1 (local-time 11 12 13)
+        t2 (local-time 12 13 14)
+        t3 (local-time 13 14 15)]
+    (is (after? t2 t1))
+    (is (after? t3 t2))
+    (is (after? t3 t1))
+    (is (not (after? t2 t3)))
+    (is (not (after? t1 t2)))
+    (is (not (after? t1 t3)))
+    ))
+
+(deftest test-time-before?
+  (let [t1 (local-time 11 12 13)
+        t2 (local-time 12 13 14)
+        t3 (local-time 13 14 15)]
+    (is (before? t1 t2))
+    (is (before? t2 t3))
+    (is (before? t1 t3))
+    (is (not (before? t3 t2)))
+    (is (not (before? t2 t1)))
+    (is (not (before? t3 t1)))
+    ))
 
 (deftest test-overlaps?
   (let [d1 (date-time 1985)

--- a/test/clj_time/format_test.clj
+++ b/test/clj_time/format_test.clj
@@ -76,6 +76,17 @@
     (is (= "20100311T000000.000"
            (unparse-local-date fmt (local-date-time 2010 3 11 00 00 00 000))))))
 
+(deftest test-local-time-parse
+  (is (= (local-time 12)
+         (parse-local-time "12:00:00")))
+  (is (= (local-time 12 13 14 15)
+         (parse-local-time "12:13:14.015"))))
+
+(deftest test-local-time-unparse
+  (let [fmt (formatter "HH:mm:ss.SSS")] ; Cannot use (formatters :local-time) here as it does not support printing
+    (is (= "13:14:15.167"
+        (unparse-local-time fmt (local-time 13 14 15 167))))))
+
 (deftest test-formatter-modifiers
   (let [fmt (formatter "YYYY-MM-dd hh:mm z" (time-zone-for-id "America/Chicago"))]
     (is (= "2010-03-11 11:49 CST"


### PR DESCRIPTION
I've put these changes into ns .core instead of a new ns .time (opposed to what @michaelklishin suggested) because the changes are minor (not warranting a new ns) and also it's just an extension to the functionality in .core. 
Fixes #134
