### PR TITLE
Add `available-ids`

### DIFF
--- a/src/clj_time/core.clj
+++ b/src/clj_time/core.clj
@@ -346,6 +346,11 @@
   [^String id]
   (DateTimeZone/forID id))
 
+(defn available-ids
+  "Returns a set of available IDs for use with time-zone-for-id."
+  []
+  (DateTimeZone/getAvailableIDs))
+
 (defn default-time-zone
   "Returns the default DateTimeZone for the current environment."
   []

--- a/test/clj_time/core_test.clj
+++ b/test/clj_time/core_test.clj
@@ -123,6 +123,9 @@
 (deftest test-time-zone-for-id
   (is (= utc (time-zone-for-id "UTC"))))
 
+(deftest test-available-ids
+  (is (some #{"UTC"} (available-ids))))
+
 (deftest test-to-time-zone
   (let [tz  (time-zone-for-offset 2)
         dt1 (date-time 1986 10 14 6)


### PR DESCRIPTION
Adds a method to return a set of the valid IDs for use with `time-zone-for-id`.
