### PR TITLE
Add in-time-unit support for Periods

### DIFF
--- a/test/clj_time/core_test.clj
+++ b/test/clj_time/core_test.clj
@@ -315,6 +315,78 @@
     (is (= 385     (in-days p)))
     (is (= 9249    (in-hours p)))))
 
+(deftest test-period-in-millis
+  (is (= 30000      (-> 30 seconds in-millis)))
+  (is (= 240000     (-> 4 minutes in-millis)))
+  (is (= 43200000   (-> 12 hours in-millis)))
+  (is (= 777600000  (-> 9 days in-millis)))
+  (is (= 1814400000 (-> 3 weeks in-millis)))
+  (is (thrown? UnsupportedOperationException (-> 2 months in-millis)))
+  (is (thrown? UnsupportedOperationException (-> 2 years in-millis))))
+
+(deftest test-period-in-seconds
+  (is (= 30      (-> 30 seconds in-seconds)))
+  (is (= 240     (-> 4 minutes in-seconds)))
+  (is (= 43200   (-> 12 hours in-seconds)))
+  (is (= 777600  (-> 9 days in-seconds)))
+  (is (= 1814400 (-> 3 weeks in-seconds)))
+  (is (thrown? UnsupportedOperationException (-> 2 months in-seconds)))
+  (is (thrown? UnsupportedOperationException (-> 2 years in-seconds))))
+
+(deftest test-period-in-minutes
+  (is (= 0     (-> 30 seconds in-minutes)))
+  (is (= 4     (-> 4 minutes in-minutes)))
+  (is (= 720   (-> 12 hours in-minutes)))
+  (is (= 12960 (-> 9 days in-minutes)))
+  (is (= 30240 (-> 3 weeks in-minutes)))
+  (is (thrown? UnsupportedOperationException (-> 2 months in-minutes)))
+  (is (thrown? UnsupportedOperationException (-> 2 years in-minutes))))
+ 
+(deftest test-period-in-hours
+  (is (= 0   (-> 30 seconds in-hours)))
+  (is (= 0   (-> 4 minutes in-hours)))
+  (is (= 12  (-> 12 hours in-hours)))
+  (is (= 216 (-> 9 days in-hours)))
+  (is (= 504 (-> 3 weeks in-hours)))
+  (is (thrown? UnsupportedOperationException (-> 2 months in-hours)))
+  (is (thrown? UnsupportedOperationException (-> 2 years in-hours))))
+
+(deftest test-period-in-days
+  (is (= 0  (-> 30 seconds in-days)))
+  (is (= 0  (-> 4 minutes in-days)))
+  (is (= 0  (-> 12 hours in-days)))
+  (is (= 9  (-> 9 days in-days)))
+  (is (= 21 (-> 3 weeks in-days)))
+  (is (thrown? UnsupportedOperationException (-> 2 months in-days)))
+  (is (thrown? UnsupportedOperationException (-> 2 years in-days))))
+
+(deftest test-period-in-weeks
+  (is (= 0  (-> 30 seconds in-weeks)))
+  (is (= 0  (-> 4 minutes in-weeks)))
+  (is (= 0  (-> 12 hours in-weeks)))
+  (is (= 1  (-> 9 days in-weeks)))
+  (is (= 3  (-> 3 weeks in-weeks)))
+  (is (thrown? UnsupportedOperationException (-> 2 months in-weeks)))
+  (is (thrown? UnsupportedOperationException (-> 2 years in-weeks))))
+
+(deftest test-period-in-months
+  (is (thrown? UnsupportedOperationException (-> 2 seconds in-months)))
+  (is (thrown? UnsupportedOperationException (-> 2 minutes in-months)))
+  (is (thrown? UnsupportedOperationException (-> 2 hours in-months)))
+  (is (thrown? UnsupportedOperationException (-> 2 days in-months)))
+  (is (thrown? UnsupportedOperationException (-> 2 weeks in-months)))
+  (is (= 7  (-> 7 months in-months)))
+  (is (= 36 (-> 3 years in-months))))
+
+(deftest test-period-in-years
+  (is (thrown? UnsupportedOperationException (-> 2 seconds in-years)))
+  (is (thrown? UnsupportedOperationException (-> 2 minutes in-years)))
+  (is (thrown? UnsupportedOperationException (-> 2 hours in-years)))
+  (is (thrown? UnsupportedOperationException (-> 2 days in-years)))
+  (is (thrown? UnsupportedOperationException (-> 2 weeks in-years)))
+  (is (= 1 (-> 14 months in-years)))
+  (is (= 3 (-> 3 years in-years))))
+
 (deftest test-within?
   (let [d1 (date-time 1985)
         d2 (date-time 1986)


### PR DESCRIPTION
Creates protocol InTimeUnitProtocol for in-<time-unit> functions and has both Interval and ReadablePeriod extend that protocol.

When a Month or Year is passed to a standard time unit (millis, seconds, minutes, hours, days, weeks), an UnsupportedOperationException is thrown courtesy of JodaTime. 

There is no good support for doing in-months or in-years with JodaTime, so I tried to do something reasonable. Specifically, if the Period is a Month or Year it will return the int, scaling of a month -> year or year -> month using the standard 12 months in a year assumption. If any other PeriodType is passed to those functions, an UnsupportedOperationException is thrown to mirror the behavior of the other functions / JodaTime.

Tests have been added, none of the previous tests changed.
