### PR TITLE
to-epoch should always return an integer number of seconds

### DIFF
--- a/src/clj_time/coerce.clj
+++ b/src/clj_time/coerce.clj
@@ -62,7 +62,7 @@
   "Convert `obj` to Unix epoch."
   [obj]
   (let [millis (to-long obj)]
-    (and millis (/ millis 1000))))
+    (and millis (quot millis 1000))))
 
 (defn to-date
   "Convert `obj` to a Java Date instance."

--- a/test/clj_time/coerce_test.clj
+++ b/test/clj_time/coerce_test.clj
@@ -124,7 +124,8 @@
   (is (= (long 0) (to-epoch 0)))
   (is (= 893462400 (to-epoch 893462400000)))
   (is (= 893462400 (to-epoch (Timestamp. 893462400000))))
-  (is (= 893462400 (to-epoch "1998-04-25T00:00:00.000Z"))))
+  (is (= 893462400 (to-epoch "1998-04-25T00:00:00.000Z")))
+  (is (= 893462400 (to-epoch "1998-04-25T00:00:00.500Z"))))
 
 (deftest test-to-string
   (is (nil? (to-string nil)))


### PR DESCRIPTION
Right now, to-epoch returns a ratio when the current time has a non-zero milliseconds part. This code ensures that it will always return an integer number of seconds, and adds a test for that case.

Authors:

Tanya Romankova
Eli Naeher