### PR TITLE
Adding the missing namespace alias to the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ access the corresponding fields:
 
 
 ``` clj
-(t/hour (date-time 1986 10 14 22))
+(t/hour (t/date-time 1986 10 14 22))
 => 22
 ```
 


### PR DESCRIPTION
I was puzzled why the namespace alias was not there for this example. Then I realized it was just missing in the README. This PR fixes that.