### PR TITLE
Adding 'week-number-of-year -> maps to Joda WeekOfWeekyear

### DIFF
--- a/src/clj_time/core.clj
+++ b/src/clj_time/core.clj
@@ -109,7 +109,8 @@
   (minus- [this ^ReadablePeriod period]
     "Returns a new date/time corresponding to the given date/time moved backwards by the given Period(s).")
   (first-day-of-the-month- [this] "Returns the first day of the month")
-  (last-day-of-the-month- [this] "Returns the last day of the month"))
+  (last-day-of-the-month- [this] "Returns the last day of the month")
+  (week-number-of-year [this] "Returs the number of weeks in the year"))
 
 (defprotocol InTimeUnitProtocol
   "Interface for in-<time unit> functions"
@@ -144,6 +145,8 @@
     (.. ^DateTime this dayOfMonth withMinimumValue))
   (last-day-of-the-month- [this]
      (.. ^DateTime this dayOfMonth withMaximumValue))
+  (week-number-of-year [this]
+    (.getWeekOfWeekyear this))
 
   org.joda.time.DateMidnight
   (year [this] (.getYear this))
@@ -166,6 +169,8 @@
     (.. ^DateMidnight this dayOfMonth withMinimumValue))
   (last-day-of-the-month- [this]
      (.. ^DateMidnight this dayOfMonth withMaximumValue))
+  (week-number-of-year [this]
+    (.getWeekOfWeekyear this))
 
   org.joda.time.LocalDateTime
   (year [this] (.getYear this))
@@ -188,6 +193,8 @@
     (.. ^LocalDateTime this dayOfMonth withMinimumValue))
   (last-day-of-the-month- [this]
      (.. ^LocalDateTime this dayOfMonth withMaximumValue))
+  (week-number-of-year [this]
+    (.getWeekOfWeekyear this))
 
   org.joda.time.YearMonth
   (year [this] (.getYear this))
@@ -210,6 +217,8 @@
     (.. ^LocalDate this dayOfMonth withMinimumValue))
   (last-day-of-the-month- [this]
      (.. ^LocalDate this dayOfMonth withMaximumValue))
+  (week-number-of-year [this]
+    (.getWeekOfWeekyear this))
 
   org.joda.time.LocalTime
   (hour [this] (.getHourOfDay this))

--- a/test/clj_time/core_test.clj
+++ b/test/clj_time/core_test.clj
@@ -515,6 +515,16 @@
     (is (= d9 (last-day-of-the-month d10)))
     (is (= d9 (last-day-of-the-month d11)))))
 
+(deftest test-week-number-of-year
+  (is (= 52 (week-number-of-year (date-time 2012 1 1))))
+  (is (= 1 (week-number-of-year (date-time 2012 1 2))))
+  (is (= 1 (week-number-of-year (date-time 2012 1 8))))
+  (is (= 2 (week-number-of-year (date-time 2012 1 9))))
+  (is (= 34 (week-number-of-year (date-time 2012 8 20))))
+  (is (= 52 (week-number-of-year (date-time 2012 12 30))))
+  (is (= 1 (week-number-of-year (date-time 2012 12 31))))
+  (is (= 1 (week-number-of-year (date-time 2013 1 1)))))
+
 (deftest test-number-of-days-in-the-month
   (is (= 31 (number-of-days-in-the-month 2012 1)))
   (is (= 31 (number-of-days-in-the-month (date-time 2012 1 3))))


### PR DESCRIPTION
The great Joda library has a property called WeekOfWeekyear,
the week-number-of-year function exposes that.

Uses the suggested name discussed in [PR 166](https://github.com/clj-time/clj-time/pull/166#issuecomment-72400776).