### PR TITLE
Add clojure.java.jdbc protocol extensions for easier coercion

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,8 @@
             :distribution :repo}
   :dependencies [[joda-time "2.7"] [org.clojure/clojure "1.6.0"]]
   :min-lein-version "2.0.0"
-  :profiles {:dev {:plugins [[codox "0.8.10"]]}
+  :profiles {:dev {:dependencies [[org.clojure/java.jdbc "0.3.6"]]
+                   :plugins [[codox "0.8.10"]]}
              :midje {:dependencies [[midje "1.6.3"]]
                      :plugins      [[lein-midje "3.1.3"]
                                     [midje-readme "1.0.3"]]

--- a/src/clj_time/jdbc.clj
+++ b/src/clj_time/jdbc.clj
@@ -1,0 +1,26 @@
+(ns clj-time.jdbc
+  "clojure.java.jdbc protocol extensions supporting DateTime coercion.
+
+  To use in your project, just require the namespace:
+
+    => (require 'clj-time.jdbc)
+    nil
+
+  Doing so will extend the protocols defined by clojure.java.jdbc, which will
+  cause java.sql.Timestamp objects in JDBC result sets to be coerced to
+  org.joda.time.DateTime objects, and vice versa where java.sql.Timestamp
+  objects would be required by JDBC."
+  (:require [clj-time.coerce :as tc]
+            [clojure.java.jdbc :as jdbc]))
+
+; http://clojure.github.io/java.jdbc/#clojure.java.jdbc/IResultSetReadColumn
+(extend-protocol jdbc/IResultSetReadColumn
+  java.sql.Timestamp
+  (result-set-read-column [v _2 _3]
+    (tc/from-sql-time v)))
+
+; http://clojure.github.io/java.jdbc/#clojure.java.jdbc/ISQLValue
+(extend-protocol jdbc/ISQLValue
+  org.joda.time.DateTime
+  (sql-value [v]
+    (tc/to-sql-time v)))

--- a/test/clj_time/jdbc_test.clj
+++ b/test/clj_time/jdbc_test.clj
@@ -1,0 +1,10 @@
+(ns clj-time.jdbc-test
+  (:require [clojure.java.jdbc :as jdbc]
+            [clojure.test :refer :all]
+            [clj-time.jdbc]))
+
+(deftest test-extends-IResultSetReadColumn
+  (is (extends? jdbc/IResultSetReadColumn java.sql.Timestamp)))
+
+(deftest test-extends-ISQLValue
+  (is (extends? jdbc/ISQLValue org.joda.time.DateTime)))


### PR DESCRIPTION
This change adds an optional development dependency on clojure.java.jdbc which
is required for tests. Presumably, users of the protocol extensions will already
have clojure.java.jdbc included in their projects, and we don't want to force
the dependency on anyone who uses clj-time.

I'm also unsure what the best method is for testing these other than to verify that the protocols are extended as we expect (as I've done) without bringing in a bigger mocking framework a la clojure.java.jdbc. This may be OK as-is.

Reference: #149