### PR TITLE
Add `overlap` that returns the overlap of two intervals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,15 @@ intervals in the corresponding temporal units:
 => 17280
 ```
 
+The `overlap` function can be used to get an `Interval` representing the
+overlap between two intervals:
+
+``` clj
+(overlap (t/interval (t/date-time 1986) (t/date-time 1990))
+         (t/interval (t/date-time 1987) (t/date-time 1991)))
+=> #<Interval 1987-01-01T00:00:00.000Z/1990-01-01T00:00:00.000Z>
+```
+
 `today-at` returns a moment in time at the given hour,
 minute and second on the current date:
 

--- a/src/clj_time/core.clj
+++ b/src/clj_time/core.clj
@@ -78,6 +78,13 @@
      => (in-minutes (interval (date-time 1986 10 2) (date-time 1986 10 14)))
      17280
 
+   The overlap function can be used to get an Interval representing the
+   overlap between two intervals:
+
+     => (overlap (t/interval (t/date-time 1986) (t/date-time 1990))
+                             (t/interval (t/date-time 1987) (t/date-time 1991)))
+     #<Interval 1987-01-01T00:00:00.000Z/1990-01-01T00:00:00.000Z>
+
    Note that all functions in this namespace work with Joda objects or ints. If
    you need to print or parse date-times, see clj-time.format. If you need to
    coerce date-times to or from other types, see clj-time.coerce."
@@ -617,6 +624,21 @@
      (or (and (before? start-b end-a) (after? end-b start-a))
          (and (after? end-b start-a) (before? start-b end-a))
          (or (equal? start-a end-b) (equal? start-b end-a)))))
+
+(defn overlap
+  "Returns an Interval representing the overlap of the specified Intervals.
+   Returns nil if the Intervals do not overlap.
+   The first argument must not be nil.
+   If the second argument is nil then the overlap of the first argument
+   and a zero duration interval with both start and end times equal to the
+   current time is returned."
+  [^Interval i-a ^Interval i-b]
+     ;; joda-time AbstractInterval.overlaps:
+     ;;    null argument means a zero length interval 'now'.
+     (cond (nil? i-b) (let [n (now)] (overlap i-a (interval n n)))
+           (.overlaps i-a i-b) (interval (latest (start i-a) (start i-b))
+                                         (earliest (end i-a) (end i-b)))
+           :else nil))
 
 (defn abuts?
   "Returns true if Interval i-a abuts i-b, i.e. then end of i-a is exactly the

--- a/test/clj_time/core_test.clj
+++ b/test/clj_time/core_test.clj
@@ -464,6 +464,28 @@
     (is (not (overlaps? ld1 ld2 ld3 ld4)))
     (is (not (overlaps? ld1 ld3 ld4 ld5)))))
 
+(deftest test-overlap
+  (let [d1 (date-time 1985)
+        d2 (date-time 1986)
+        d3 (date-time 1987)
+        d4 (date-time 1988)
+        n (now)
+        n1 (minus n (minutes 5))
+        n2 (plus n (minutes 5))]
+    (is (nil? (overlap (interval d1 d2) nil)))
+    (is (let [t (overlap (interval n1 n2) nil)]
+          ;; nil is a zero length duration at 'now'
+          (and
+            (< (in-millis (interval n (start t))) 1000)
+            (= 0 (in-millis t)))))
+    (is (= (interval d2 d2) (overlap (interval d1 d3) (interval d2 d2))))
+    (is (nil? (overlap (interval d1 d1) (interval d1 d1)))) ;; The intervals abut
+    (is (nil? (overlap (interval d1 d2) (interval d2 d3)))) ;; The intervals abut
+    (is (= (interval d2 d3) (overlap (interval d1 d3) (interval d2 d4))))
+    (is (= (interval d2 d3) (overlap (interval d1 d3) (interval d2 d3))))
+    (is (nil? (overlap (interval d1 d2) (interval d2 d3))))
+    (is (nil? (overlap (interval d1 d2) (interval d3 d4))))))
+
 (deftest test-abuts?
   (let [d1 (date-time 1985)
         d2 (date-time 1986)


### PR DESCRIPTION
`overlap` returns an Interval whenever the arguments satisfy `overlaps?`,
otherwise it returns nil.

Two cases to higlight:
* When null is passed to joda-time's overlap method it means 'a zero
  duration interval at now'. Therefore when nil is passed as the second
  argument of `overlap` we should return the overlap of the first argument
  and a zero duration interval with both start and end times equal to the
  current time.

* Two zero duration intervals at the same DateTime do not satisfy
  `overlaps?` (they satisfy `abuts?`) so `overlap` should return nil in this
   case.