### PR TITLE
Accept optional tz argument for to-local-date.

### DIFF
--- a/src/clj_time/coerce.clj
+++ b/src/clj_time/coerce.clj
@@ -107,6 +107,14 @@
   (if-let [dt (to-date-time obj)]
     (LocalDateTime. (.getMillis (from-time-zone dt (default-time-zone))))))
 
+(defn in-time-zone
+  "Convert `obj` into `tz`, return org.joda.time.LocalDate instance."
+  [obj tz]
+  (if-let [dt (to-date-time obj)]
+    (-> dt
+        (to-time-zone tz)
+        .toLocalDate)))
+
 (extend-protocol ICoerce
   nil
   (to-date-time [_]

--- a/test/clj_time/coerce_test.clj
+++ b/test/clj_time/coerce_test.clj
@@ -175,3 +175,26 @@
   (is (= (LocalDateTime. 1970 1 1 0 0) (to-local-date-time 0)))
   (is (= (LocalDateTime. 1998 4 25 0 0 55 0) (to-local-date-time 893462455000)))
   (is (= (LocalDateTime. 1998 4 25 10 20 30 400) (to-local-date-time "1998-04-25T10:20:30.400Z"))))
+
+(deftest test-in-time-zone
+  (testing "negative time zone offsets close to date boundary return previous day"
+    (is (= (in-time-zone (date-time 2015 5 5 0 0)
+                         (time-zone-for-offset 0 0))
+           (local-date 2015 5 5)))
+
+    (is (= (in-time-zone (date-time 2015 5 5 0 0)
+                         (time-zone-for-offset -1 0))
+           (local-date 2015 5 4)))
+
+    (is (= (in-time-zone (date-time 2015 5 5 0 0)
+                         (time-zone-for-offset 1 0))
+           (local-date 2015 5 5))))
+
+  (testing "positive time zone offsets close to date boundary return next day"
+    (is (= (in-time-zone (date-time 2015 5 5 20 0)
+                         (time-zone-for-offset 5 0))
+           (local-date 2015 5 6)))
+
+    (is (= (in-time-zone (date-time 2015 5 5 20 0)
+                         (time-zone-for-offset 3 0))
+           (local-date 2015 5 5)))))


### PR DESCRIPTION
My use case centers around having instants (in UTC) but wanting to be able to render the correct date on the server for non-browser clients in other time zones than the server time zone (also UTC). If there's a better way to do this please let me know. Thanks.