### PR TITLE
Clean up ns declarations

### DIFF
--- a/src/clj_time/coerce.clj
+++ b/src/clj_time/coerce.clj
@@ -8,11 +8,12 @@
      => (from-long 893462400000)
      #<DateTime 1998-04-25T00:00:00.000Z>"
   (:refer-clojure :exclude [extend second])
-  (:use clj-time.core)
-  (:require [clj-time.format :as time-fmt])
-  (:import (org.joda.time DateTime DateTimeZone DateMidnight YearMonth
-                          LocalDate LocalDateTime))
-  (:import java.util.Date java.sql.Timestamp))
+  (:require [clj-time.core :refer :all]
+            [clj-time.format :as time-fmt])
+  (:import [java.sql Timestamp]
+           [java.util Date]
+           [org.joda.time DateTime DateTimeZone DateMidnight YearMonth
+                          LocalDate LocalDateTime]))
 
 (defprotocol ICoerce
   (^org.joda.time.DateTime

--- a/src/clj_time/core.clj
+++ b/src/clj_time/core.clj
@@ -89,11 +89,12 @@
    you need to print or parse date-times, see clj-time.format. If you need to
    coerce date-times to or from other types, see clj-time.coerce."
   (:refer-clojure :exclude [extend second])
-  (:import (org.joda.time ReadablePartial ReadableDateTime ReadableInstant ReadablePeriod DateTime
-                          DateMidnight YearMonth LocalDate LocalTime DateTimeZone Period PeriodType Interval
-                          Years Months Weeks Days Hours Minutes Seconds LocalDateTime MutableDateTime
-                          DateTimeUtils)
-           (org.joda.time.base BaseDateTime)))
+  (:import [org.joda.time ReadablePartial ReadableDateTime ReadableInstant
+                          ReadablePeriod DateTime DateMidnight YearMonth
+                          LocalDate LocalTime DateTimeZone Period PeriodType
+                          Interval Years Months Weeks Days Hours Minutes Seconds
+                          LocalDateTime MutableDateTime DateTimeUtils]
+           [org.joda.time.base BaseDateTime]))
 
 (defn deprecated [message]
   (println "DEPRECATION WARNING: " message))

--- a/src/clj_time/format.clj
+++ b/src/clj_time/format.clj
@@ -26,14 +26,14 @@
    etc with the functions with-zone, with-locale, with-chronology,
    with-default-year and with-pivot-year."
   (:refer-clojure :exclude [extend second])
-  (:use [clojure.set :only (difference)])
-  (:use clj-time.core)
-  (:import (java.util Locale)
-           (org.joda.time Chronology DateTime DateTimeZone Interval LocalDateTime
-                          Period PeriodType LocalDate LocalTime)
-           (org.joda.time.format DateTimeFormat DateTimeFormatter DateTimePrinter
-                                 DateTimeFormatterBuilder DateTimeParser
-                                 ISODateTimeFormat)))
+  (:require [clj-time.core :refer :all]
+            [clojure.set :refer [difference]])
+  (:import [java.util Locale]
+           [org.joda.time Chronology DateTime DateTimeZone Interval
+                          LocalDateTime Period PeriodType LocalDate LocalTime]
+           [org.joda.time.format DateTimeFormat DateTimeFormatter
+                                 DateTimePrinter DateTimeFormatterBuilder
+                                 DateTimeParser ISODateTimeFormat]))
 
 (declare formatter)
 ;; The formatters map and show-formatters idea are strait from chrono.

--- a/src/clj_time/local.clj
+++ b/src/clj_time/local.clj
@@ -27,8 +27,8 @@
   (:require [clj-time.core :as time]
             [clj-time.coerce :as coerce]
             [clj-time.format :as fmt])
-  (:import (org.joda.time DateTime DateTimeZone)
-           (org.joda.time.format DateTimeFormatter)))
+  (:import [org.joda.time DateTime DateTimeZone]
+           [org.joda.time.format DateTimeFormatter]))
 
 (def ^{:doc "Map of local formatters for parsing and printing." :dynamic true}
   *local-formatters*

--- a/test/clj_time/coerce_test.clj
+++ b/test/clj_time/coerce_test.clj
@@ -1,7 +1,7 @@
 (ns clj-time.coerce-test
   (:refer-clojure :exclude [extend second])
-  (:use clojure.test)
-  (:use (clj-time core coerce))
+  (:require [clojure.test :refer :all]
+            [clj-time [core :refer :all] [coerce :refer :all]])
   (:import java.util.Date java.sql.Timestamp
            [org.joda.time LocalDate LocalDateTime]))
 

--- a/test/clj_time/core_test.clj
+++ b/test/clj_time/core_test.clj
@@ -1,7 +1,7 @@
 (ns clj-time.core-test
   (:refer-clojure :exclude [extend second])
-  (:use clojure.test
-        clj-time.core)
+  (:require [clojure.test :refer :all]
+            [clj-time.core :refer :all])
   (:import java.util.Date
            org.joda.time.DateTime))
 

--- a/test/clj_time/format_test.clj
+++ b/test/clj_time/format_test.clj
@@ -1,7 +1,7 @@
 (ns clj-time.format-test
   (:refer-clojure :exclude [extend second])
-  (:use clojure.test
-        (clj-time core format))
+  (:require [clojure.test :refer :all]
+            [clj-time [core :refer :all] [format :refer :all]])
   (:import [org.joda.time DateTimeZone]
            java.util.Locale))
 

--- a/test/clj_time/local_test.clj
+++ b/test/clj_time/local_test.clj
@@ -1,8 +1,8 @@
 (ns clj-time.local-test
-  (:use clojure.test clj-time.local
-        [clj-time.core-test :only (when-available when-not-available)])
-  (:require (clj-time [core :as time] [format :as fmt]))
-  (:import (org.joda.time.format ISODateTimeFormat)
+  (:require [clojure.test :refer :all]
+            [clj-time [core :as time] [format :as fmt] [local :refer :all]]
+            [clj-time.core-test :refer [when-available when-not-available]])
+  (:import [org.joda.time.format ISODateTimeFormat]
            java.util.Date java.sql.Timestamp))
 
 (deftest test-now

--- a/test/clj_time/periodic_test.clj
+++ b/test/clj_time/periodic_test.clj
@@ -1,8 +1,7 @@
 (ns clj-time.periodic-test
-  (:use clojure.test
-        [clj-time.core :only [date-time hours months]]
-        clj-time.periodic))
-
+  (:require [clojure.test :refer :all]
+            [clj-time.core :refer [date-time hours months]]
+            [clj-time.periodic :refer :all]))
 
 (deftest test-periodic-sequence
   (let [d0 (date-time 2012 3 3 20 0)

--- a/test/clj_time/predicates_test.clj
+++ b/test/clj_time/predicates_test.clj
@@ -1,7 +1,7 @@
 (ns clj-time.predicates-test
   (:refer-clojure :exclude [extend second])
-  (:use clojure.test)
-  (:use [clj-time core predicates]))
+  (:require [clojure.test :refer :all]
+            [clj-time [core :refer :all] [predicates :refer :all]]))
 
 (deftest test-days-of-the-week
   (is (= true (monday? (date-time 2012 9 10))))


### PR DESCRIPTION
This is only cleanup related to style and issues found by [Eastwood](https://github.com/jonase/eastwood), there should be no functional changes.

- Remove unlimited :use references
- Be more consistent with use of square brackets in :import references