### PR TITLE
Fix tests with mistaken 1-arg `=` calls

### DIFF
--- a/test/clj_time/core_test.clj
+++ b/test/clj_time/core_test.clj
@@ -275,8 +275,8 @@
       (is (= d1 (earliest [d4 d2 d3 d1])))
       (is (= d2 (earliest [d4 d3 d2])))
       (is (= d4 (earliest [d4])))
-      (is (= Exception) (earliest [d1 d2 nil]))
-      (is (= Exception) (earliest d2 nil))))
+      (is (nil? (earliest [d1 d2 nil])))
+      (is (nil? (earliest d2 nil)))))
 
 (deftest test-latest
     (let [d1 (date-time 1990 1 1 23 1 1)
@@ -290,8 +290,8 @@
       (is (= d4 (latest [d4 d2 d3 d1])))
       (is (= d3 (latest [d2 d3 d1])))
       (is (= d1 (latest [d1])))
-      (is (= Exception) (latest [d1 d2 nil]))
-      (is (= Exception) (latest d2 nil))))
+      (is (= d2 (latest [d1 d2 nil])))
+      (is (= d2 (latest d2 nil)))))
 
 (deftest test-start-end
   (let [s (date-time 1986 10 14 12 5 4)


### PR DESCRIPTION
An issue found by https://github.com/jonase/eastwood

`(= Exception)` is trivially true, so it seems the intent was to compare this against the return values of `earliest` and `latest`. However, I've only updated the tests to pass with the current behavior, I'm not sure if the current behavior is actually desired. It seems `nil` simply compares before all other dates/times.