### PR TITLE
Adds sql.Date and sql.Time auto-coerce to clj-time.jdbc

### DIFF
--- a/src/clj_time/jdbc.clj
+++ b/src/clj_time/jdbc.clj
@@ -17,7 +17,13 @@
 (extend-protocol jdbc/IResultSetReadColumn
   java.sql.Timestamp
   (result-set-read-column [v _2 _3]
-    (tc/from-sql-time v)))
+    (tc/from-sql-time v))
+  java.sql.Date
+  (result-set-read-column [v _2 _3]
+    (tc/from-sql-date v))
+  java.sql.Time
+  (result-set-read-column [v _2 _3]
+    (org.joda.time.DateTime. v)))
 
 ; http://clojure.github.io/java.jdbc/#clojure.java.jdbc/ISQLValue
 (extend-protocol jdbc/ISQLValue

--- a/test/clj_time/jdbc_test.clj
+++ b/test/clj_time/jdbc_test.clj
@@ -4,7 +4,9 @@
             [clj-time.jdbc]))
 
 (deftest test-extends-IResultSetReadColumn
-  (is (extends? jdbc/IResultSetReadColumn java.sql.Timestamp)))
+  (is (extends? jdbc/IResultSetReadColumn java.sql.Timestamp))
+  (is (extends? jdbc/IResultSetReadColumn java.sql.Date))
+  (is (extends? jdbc/IResultSetReadColumn java.sql.Time)))
 
 (deftest test-extends-ISQLValue
   (is (extends? jdbc/ISQLValue org.joda.time.DateTime)))


### PR DESCRIPTION
Don't know how many databases out there actually represent dates and times as separate types (different from timestamps) but I don't think it'll hurt to cover them.