### PR TITLE
Allow formatter to accept keyword args.

### DIFF
--- a/src/clj_time/format.clj
+++ b/src/clj_time/format.clj
@@ -35,15 +35,17 @@
                                  DateTimePrinter DateTimeFormatterBuilder
                                  DateTimeParser ISODateTimeFormat]))
 
-(declare formatter)
+(declare formatters)
 ;; The formatters map and show-formatters idea are strait from chrono.
 
 (defn formatter
-  "Returns a custom formatter for the given date-time pattern."
-  ([^String fmts]
+  "Returns a custom formatter for the given date-time pattern or keyword."
+  ([fmts]
      (formatter fmts utc))
-  ([^String fmts ^DateTimeZone dtz]
-     (.withZone (DateTimeFormat/forPattern fmts) dtz))
+  ([fmts ^DateTimeZone dtz]
+   (if-let [dtf ^DateTimeFormatter (get formatters fmts)]
+     (.withZone dtf dtz)
+     (.withZone (DateTimeFormat/forPattern fmts) dtz)))
   ([^DateTimeZone dtz fmts & more]
     (let [printer (.getPrinter ^DateTimeFormatter (formatter fmts dtz))
           parsers (map #(.getParser ^DateTimeFormatter (formatter % dtz)) (cons fmts more))]

--- a/test/clj_time/format_test.clj
+++ b/test/clj_time/format_test.clj
@@ -6,9 +6,15 @@
            java.util.Locale))
 
 (deftest test-formatter
-  (let [fmt (formatter "yyyyMMdd")]
-    (is (= (date-time 2010 3 11)
-           (parse fmt "20100311")))))
+  (testing "with string pattern"
+    (let [fmt (formatter "yyyyMMdd")]
+      (is (= (date-time 2010 3 11)
+             (parse fmt "20100311")))))
+  (testing "with keyword"
+    (let [dtz (time-zone-for-id "America/Detroit")
+          fmt (formatter dtz :year-month-day :basic-date "YY/dd/MM")]
+      (is (= (from-time-zone (date-time 1997 06 17) dtz)
+             (parse fmt "97/17/06"))))))
 
 (deftest test-formatter-local
   (let [fmt (formatter-local "yyyyMMdd")]


### PR DESCRIPTION
- Avoids reflection, but adds a map lookup.
- We look if fmts is in the formatters map first.  If not, we assume it
  is a string, and can be retrieved with the normal
  `DateTimeFormat/forPattern` approach.
- I'm not sure why there was a `(declare formatter)` block given that
  formatter is the very next function in the ns, but I changed it
  to `(declare formatters)`, and now that is meaningful as well.