### PR TITLE
Fix reflection warnings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,7 @@
   :dependencies [[joda-time "2.9.4"]
                  [org.clojure/clojure "1.8.0" :scope "provided"]]
   :min-lein-version "2.0.0"
+  :global-vars {*warn-on-reflection* true}
   :profiles {:dev {:dependencies [[org.clojure/java.jdbc "0.6.1"]]
                    :plugins [[codox "0.8.10"]]}
              :midje {:dependencies [[midje "1.9.0-alpha5"]]

--- a/src/clj_time/core.clj
+++ b/src/clj_time/core.clj
@@ -770,6 +770,7 @@
    (let [dt-fns [year month day hour minute second milli]
          tz (.getZone dt)]
     (.withZoneRetainFields
+                ^DateTime
   	 	(apply date-time
   	 		(map apply
   				(concat (take-while (partial not= dt-fn) dt-fns) [dt-fn])

--- a/test/clj_time/local_test.clj
+++ b/test/clj_time/local_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer :all]
             [clj-time [core :as time] [format :as fmt] [local :refer :all]]
             [clj-time.core-test :refer [when-available when-not-available]])
-  (:import [org.joda.time.format ISODateTimeFormat]
+  (:import [org.joda.time DateTime]
+           [org.joda.time.format ISODateTimeFormat]
            java.util.Date java.sql.Timestamp))
 
 (deftest test-now
@@ -55,7 +56,7 @@
                 (is (= "04/25/1998 11:59:01" (format-local-time (time/date-time 1998 4 25 11 59 1) :mmddyyyy-hhmmss-slash)))
                 (is (= (time/from-time-zone (time/date-time 1998 4 25 11 59 1) (time/default-time-zone))
                        (to-local-date-time "04/25/1998 11:59:01")))
-                (is (= (time/default-time-zone) (.getZone (to-local-date-time "04/25/1998 11:59:01")))))))]
+                (is (= (time/default-time-zone) (.getZone ^DateTime (to-local-date-time "04/25/1998 11:59:01")))))))]
     (when-available
      with-redefs
      (with-redefs [time/default-time-zone time-zone-fn]


### PR DESCRIPTION
Adds type hints where indicated by compiler, and enable refection warnings in
leiningen builds to help avoid future regressions.