### PR TITLE
return type hints

### DIFF
--- a/src/clj_time/coerce.clj
+++ b/src/clj_time/coerce.clj
@@ -16,37 +16,36 @@
                           LocalDate LocalDateTime]))
 
 (defprotocol ICoerce
-  (^org.joda.time.DateTime
-    to-date-time [obj] "Convert `obj` to a Joda DateTime instance."))
+  (to-date-time ^DateTime [obj] "Convert `obj` to a Joda DateTime instance."))
 
-(defn from-long
+(defn ^DateTime from-long
   "Returns a DateTime instance in the UTC time zone corresponding to the given
    number of milliseconds after the Unix epoch."
   [^Long millis]
   (DateTime. millis ^DateTimeZone utc))
 
-(defn from-string
+(defn ^DateTime from-string
   "return DateTime instance from string using
    formatters in clj-time.format, returning first
    which parses"
   [^String s]
   (time-fmt/parse s))
 
-(defn from-date
+(defn ^DateTime from-date
   "Returns a DateTime instance in the UTC time zone corresponding to the given
    Java Date object."
   [^Date date]
   (when date
     (from-long (.getTime date))))
 
-(defn from-sql-date
+(defn ^DateTime from-sql-date
   "Returns a DateTime instance in the UTC time zone corresponding to the given
    java.sql.Date object."
   [^java.sql.Date sql-date]
   (when sql-date
     (from-long (.getTime sql-date))))
 
-(defn from-sql-time
+(defn ^DateTime from-sql-time
   "Returns a DateTime instance in the UTC time zone corresponding to the given
    java.sql.Timestamp object."
   [^java.sql.Timestamp sql-time]
@@ -65,19 +64,19 @@
   (let [millis (to-long obj)]
     (and millis (quot millis 1000))))
 
-(defn to-date
+(defn ^Date to-date
   "Convert `obj` to a Java Date instance."
   [obj]
   (if-let [dt (to-date-time obj)]
     (Date. (.getMillis dt))))
 
-(defn to-sql-date
+(defn ^java.sql.Date to-sql-date
   "Convert `obj` to a java.sql.Date instance."
   [obj]
   (if-let [dt (to-date-time obj)]
     (java.sql.Date. (.getMillis dt))))
 
-(defn to-sql-time
+(defn ^java.sql.Timestamp to-sql-time
   "Convert `obj` to a java.sql.Timestamp instance."
   [obj]
   (if-let [dt (to-date-time obj)]
@@ -87,28 +86,28 @@
   "Returns a string representation of obj in UTC time-zone
   using (ISODateTimeFormat/dateTime) date-time representation."
   [obj]
-  (if-let [^DateTime dt (to-date-time obj)]
+  (if-let [dt (to-date-time obj)]
     (time-fmt/unparse (:date-time time-fmt/formatters) dt)))
 
-(defn to-timestamp
+(defn ^java.sql.Timestamp to-timestamp
   "Convert `obj` to a Java SQL Timestamp instance."
   [obj]
   (if-let [dt (to-date-time obj)]
-    (Timestamp. (.getMillis dt))))
+    (java.sql.Timestamp. (.getMillis dt))))
 
-(defn to-local-date
+(defn ^LocalDate to-local-date
   "Convert `obj` to a org.joda.time.LocalDate instance"
   [obj]
   (if-let [dt (to-date-time obj)]
     (LocalDate. (.getMillis (from-time-zone dt (default-time-zone))))))
 
-(defn to-local-date-time
+(defn ^LocalDateTime to-local-date-time
   "Convert `obj` to a org.joda.time.LocalDateTime instance"
   [obj]
   (if-let [dt (to-date-time obj)]
     (LocalDateTime. (.getMillis (from-time-zone dt (default-time-zone))))))
 
-(defn in-time-zone
+(defn ^LocalDate in-time-zone
   "Convert `obj` into `tz`, return org.joda.time.LocalDate instance."
   [obj tz]
   (if-let [dt (to-date-time obj)]
@@ -167,6 +166,6 @@
   (to-date-time [string]
     (from-string string))
 
-  Timestamp
+  java.sql.Timestamp
   (to-date-time [timestamp]
     (from-date timestamp)))

--- a/src/clj_time/format.clj
+++ b/src/clj_time/format.clj
@@ -38,7 +38,7 @@
 (declare formatters)
 ;; The formatters map and show-formatters idea are strait from chrono.
 
-(defn formatter
+(defn ^DateTimeFormatter formatter
   "Returns a custom formatter for the given date-time pattern or keyword."
   ([fmts]
      (formatter fmts utc))
@@ -56,32 +56,32 @@
         (.toFormatter)
         (.withZone dtz)))))
 
-(defn formatter-local
+(defn ^DateTimeFormat formatter-local
   "Returns a custom formatter with no time zone info."
   ([^String fmt]
      (DateTimeFormat/forPattern fmt)))
 
-(defn with-chronology
+(defn ^DateTimeFormatter with-chronology
   "Return a copy of a formatter that uses the given Chronology."
   [^DateTimeFormatter f ^Chronology c]
   (.withChronology f c))
 
-(defn with-locale
+(defn ^DateTimeFormatter with-locale
   "Return a copy of a formatter that uses the given Locale."
   [^DateTimeFormatter f ^Locale l]
   (.withLocale f l))
 
-(defn with-pivot-year
+(defn ^DateTimeFormatter with-pivot-year
   "Return a copy of a formatter that uses the given pivot year."
   [^DateTimeFormatter f ^Long pivot-year]
   (.withPivotYear f pivot-year))
 
-(defn with-zone
+(defn ^DateTimeFormatter with-zone
   "Return a copy of a formatter that uses the given DateTimeZone."
   [^DateTimeFormatter f ^DateTimeZone dtz]
   (.withZone f dtz))
 
-(defn with-default-year
+(defn ^DateTimeFormatter with-default-year
   "Return a copy of a formatter that uses the given default year."
   [^DateTimeFormatter f ^Integer default-year]
   (.withDefaultYear f default-year))
@@ -153,7 +153,7 @@
 (def ^{:private true} printers
   (difference (set (keys formatters)) parsers))
 
-(defn parse
+(defn ^DateTime parse
   "Returns a DateTime instance in the UTC time zone obtained by parsing the
    given string according to the given formatter."
   ([^DateTimeFormatter fmt ^String s]
@@ -164,7 +164,7 @@
             :let [d (try (parse f s) (catch Exception _ nil))]
             :when d] d))))
 
-(defn parse-local
+(defn ^LocalDateTime parse-local
   "Returns a LocalDateTime instance obtained by parsing the
    given string according to the given formatter."
   ([^DateTimeFormatter fmt ^String s]
@@ -175,7 +175,7 @@
             :let [d (try (parse-local f s) (catch Exception _ nil))]
             :when d] d))))
 
-(defn parse-local-date
+(defn ^LocalDate parse-local-date
   "Returns a LocalDate instance obtained by parsing the
    given string according to the given formatter."
   ([^DateTimeFormatter fmt ^String s]
@@ -186,7 +186,7 @@
             :let [d (try (parse-local-date f s) (catch Exception _ nil))]
             :when d] d))))
 
-(defn parse-local-time
+(defn ^LocalTime parse-local-time
   "Returns a LocalTime instance obtained by parsing the
   given string according to the given formatter."
   ([^DateTimeFormatter fmt ^ String s]


### PR DESCRIPTION
Since clj-time doesn't wrap all of joda-time api, I thought it would be convenient to type-hint return values that are instances from joda-time, for cases where users call the native library because they have no clj-time wrapper.