### PR TITLE
Define some type predicates and related clojure.spec definitions.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,5 +20,8 @@
              :1.6    {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.7    {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :master {:repositories [["snapshots" "https://oss.sonatype.org/content/repositories/snapshots/"]]
-                      :dependencies [[org.clojure/clojure "1.9.0-master-SNAPSHOT"]]}}
+                      :dependencies [[org.clojure/clojure "1.9.0-master-SNAPSHOT"]]}
+             :spec   {:dependencies [[org.clojure/clojure "1.9.0-alpha14"]
+                                     [org.clojure/test.check "0.9.0"]]}}
+
   :aliases {"test-all" ["with-profile" "dev,master,default,midje:dev,default,midje:dev,1.6,midje:dev,1.7,midje" "test"]})

--- a/project.clj
+++ b/project.clj
@@ -22,6 +22,7 @@
              :master {:repositories [["snapshots" "https://oss.sonatype.org/content/repositories/snapshots/"]]
                       :dependencies [[org.clojure/clojure "1.9.0-master-SNAPSHOT"]]}
              :spec   {:dependencies [[org.clojure/clojure "1.9.0-alpha14"]
-                                     [org.clojure/test.check "0.9.0"]]}}
+                                     [org.clojure/test.check "0.9.0"]]
+                      :test-paths ["test" "test_clj_1.9"]}}
 
   :aliases {"test-all" ["with-profile" "dev,master,default,midje:dev,default,midje:dev,1.6,midje:dev,1.7,midje" "test"]})

--- a/src/clj_time/spec.clj
+++ b/src/clj_time/spec.clj
@@ -2,32 +2,12 @@
   "This namespace requires Clojure 1.9 or later. It defines a set of predicates plus a set of spec defs with associated generators."
   (:require [clojure.spec :as spec]
             [clojure.spec.gen :as gen]
+            [clj-time.types :refer [date-time? local-date-time? local-date? time-zone?]]
             [clj-time.core :refer [date-time]]
             [clj-time.coerce :refer [to-date-time to-long]])
   (:import [org.joda.time DateTime DateTimeZone LocalDate LocalDateTime]
            [org.joda.time.base BaseDateTime]
            [java.util TimeZone]))
-
-(defn date-time?
-  "This includes DateTime, MutableDateTime and DateMidnight. The time zone is not specified."
-  [x]
-  (instance? BaseDateTime x))
-
-(defn
-  ^{::spec/name "clj-time.spec/utc-date-time?"}
-  utc-date-time?
-  [x]
-  (and (date-time? x)
-       (= (.getZone ^BaseDateTime x) DateTimeZone/UTC)))
-
-(defn local-date-time? [x]
-  (instance? LocalDateTime x))
-
-(defn local-date? [x]
-  (instance? LocalDate x))
-
-(defn time-zone? [x]
-  (instance? DateTimeZone x))
 
 (def all-time-zones
   (delay
@@ -59,8 +39,8 @@
 (spec/def ::time-zone
           (spec/with-gen time-zone? *time-zones*))
 
-(spec/def ::utc-date-time
-          (spec/with-gen utc-date-time?
+(spec/def ::date-time
+          (spec/with-gen date-time?
                          #(gen/fmap (fn [ms] (DateTime. ms DateTimeZone/UTC))
                                     (*period*))))
 

--- a/src/clj_time/spec.clj
+++ b/src/clj_time/spec.clj
@@ -1,0 +1,87 @@
+(ns clj-time.spec
+  "This namespace requires Clojure 1.9 or later. It defines a set of predicates plus a set of spec defs with associated generators."
+  (:require [clojure.spec :as spec]
+            [clojure.spec.gen :as gen]
+            [clj-time.core :refer [date-time]]
+            [clj-time.coerce :refer [to-date-time to-long]])
+  (:import [org.joda.time DateTime DateTimeZone LocalDate LocalDateTime]
+           [org.joda.time.base BaseDateTime]
+           [java.util TimeZone]))
+
+(defn date-time?
+  "This includes DateTime, MutableDateTime and DateMidnight. The time zone is not specified."
+  [x]
+  (instance? BaseDateTime x))
+
+(defn utc-date-time? [x]
+  (and (date-time? x)
+       (= (.getZone ^BaseDateTime x) DateTimeZone/UTC)))
+
+(defn local-date-time? [x]
+  (instance? LocalDateTime x))
+
+(defn local-date? [x]
+  (instance? LocalDate x))
+
+(defn time-zone? [x]
+  (instance? DateTimeZone x))
+
+(def all-time-zones
+  (delay
+    (set
+      (keep #(try (DateTimeZone/forTimeZone (TimeZone/getTimeZone ^String %))
+                  (catch Throwable t nil))
+            (TimeZone/getAvailableIDs)))))
+
+(defn ^:dynamic *time-zones*
+  "Dynamically bind this to choose which time zones to use in generators."
+  []
+  (gen/one-of [(gen/return DateTimeZone/UTC)
+               (spec/gen @all-time-zones)]))
+
+(spec/def ::modern-era (spec/int-in (to-long (date-time 2006 3 24 14 49 31))
+                                    (to-long (date-time 2017 1 20 16 00 00))))
+
+(spec/def ::questionable-future (spec/int-in (to-long (date-time 2017 1 20 16 00 00))
+                                             (to-long (date-time 2030 12 31 23 59 59))))
+
+(defn ^:dynamic *period*
+  "Dynamically bind this to choose the range of your generated dates."
+  []
+  (gen/one-of [(spec/gen ::modern-era) (spec/gen ::questionable-future)]))
+
+(spec/def ::time-zone
+          (spec/with-gen time-zone? *time-zones*))
+
+; FIXME: despite specifying a time zone, this seems to always produce UTC. I don't know what I'm doing wrong.
+(spec/def ::date-time
+          (spec/with-gen utc-date-time?
+                         #(gen/fmap (fn [[ms tz]]
+                                      (DateTime. ms ^DateTimeZone tz))
+                                    (gen/tuple (*period*)
+                                               (*time-zones*)))))
+
+(spec/def ::utc-date-time
+          (spec/with-gen utc-date-time?
+                         #(gen/fmap (fn [ms] (DateTime. ms DateTimeZone/UTC))
+                                    (*period*))))
+
+(spec/def ::local-date
+          (spec/with-gen local-date?
+                         #(gen/fmap (fn [ms] (LocalDate. ms))
+                                    (*period*))))
+
+(spec/def ::local-date-time
+          (spec/with-gen local-date-time?
+                         #(gen/fmap (fn [ms] (LocalDateTime. ms))
+                                    (*period*))))
+
+
+(comment
+  (gen/sample (spec/gen ::utc-date-time))
+  (gen/sample (spec/gen ::local-date))
+  (gen/sample (spec/gen ::local-date-time))
+  (binding [*period* #(spec/gen int?)]
+    (gen/sample (spec/gen ::local-date)))
+  (gen/sample (spec/gen ::time-zone))
+  (map #(.getZone ^DateTime %) (gen/sample (spec/gen ::date-time))))

--- a/src/clj_time/spec.clj
+++ b/src/clj_time/spec.clj
@@ -13,7 +13,10 @@
   [x]
   (instance? BaseDateTime x))
 
-(defn utc-date-time? [x]
+(defn
+  ^{::spec/name "clj-time.spec/utc-date-time?"}
+  utc-date-time?
+  [x]
   (and (date-time? x)
        (= (.getZone ^BaseDateTime x) DateTimeZone/UTC)))
 
@@ -39,27 +42,22 @@
   (gen/one-of [(gen/return DateTimeZone/UTC)
                (spec/gen @all-time-zones)]))
 
-(spec/def ::modern-era (spec/int-in (to-long (date-time 2006 3 24 14 49 31))
-                                    (to-long (date-time 2017 1 20 16 00 00))))
+(spec/def ::past (spec/int-in (to-long (date-time 2001 1 1 00 00 00))
+                              (to-long (date-time 2010 12 31 00 00 00))))
 
-(spec/def ::questionable-future (spec/int-in (to-long (date-time 2017 1 20 16 00 00))
-                                             (to-long (date-time 2030 12 31 23 59 59))))
+(spec/def ::past-and-future (spec/int-in (to-long (date-time 2011 1 1 00 00 00))
+                                         (to-long (date-time 2030 12 31 23 59 59))))
+
+(spec/def ::future (spec/int-in (to-long (date-time 2031 1 1 0 00 00))
+                                (to-long (date-time 2040 12 31 23 59 59))))
 
 (defn ^:dynamic *period*
   "Dynamically bind this to choose the range of your generated dates."
   []
-  (gen/one-of [(spec/gen ::modern-era) (spec/gen ::questionable-future)]))
+  (spec/gen ::past-and-future))
 
 (spec/def ::time-zone
           (spec/with-gen time-zone? *time-zones*))
-
-; FIXME: despite specifying a time zone, this seems to always produce UTC. I don't know what I'm doing wrong.
-(spec/def ::date-time
-          (spec/with-gen utc-date-time?
-                         #(gen/fmap (fn [[ms tz]]
-                                      (DateTime. ms ^DateTimeZone tz))
-                                    (gen/tuple (*period*)
-                                               (*time-zones*)))))
 
 (spec/def ::utc-date-time
           (spec/with-gen utc-date-time?
@@ -75,13 +73,3 @@
           (spec/with-gen local-date-time?
                          #(gen/fmap (fn [ms] (LocalDateTime. ms))
                                     (*period*))))
-
-
-(comment
-  (gen/sample (spec/gen ::utc-date-time))
-  (gen/sample (spec/gen ::local-date))
-  (gen/sample (spec/gen ::local-date-time))
-  (binding [*period* #(spec/gen int?)]
-    (gen/sample (spec/gen ::local-date)))
-  (gen/sample (spec/gen ::time-zone))
-  (map #(.getZone ^DateTime %) (gen/sample (spec/gen ::date-time))))

--- a/src/clj_time/types.clj
+++ b/src/clj_time/types.clj
@@ -1,0 +1,17 @@
+(ns clj-time.types
+  "This namespace defines a set of predicates for the various Joda Time types used by clj-time."
+  (:import [org.joda.time DateTimeZone LocalDate LocalDateTime]
+           [org.joda.time.base BaseDateTime]))
+
+(defn date-time? [x]
+  (and (instance? BaseDateTime x)
+       (= (.getZone ^BaseDateTime x) DateTimeZone/UTC)))
+
+(defn local-date-time? [x]
+  (instance? LocalDateTime x))
+
+(defn local-date? [x]
+  (instance? LocalDate x))
+
+(defn time-zone? [x]
+  (instance? DateTimeZone x))

--- a/test/clj_time/types_test.clj
+++ b/test/clj_time/types_test.clj
@@ -1,0 +1,19 @@
+(ns clj-time.types-test
+  (:require [clojure.test :refer :all]
+            [clj-time.types :as types]
+            [clj-time.core :refer :all]))
+
+(deftest test-predicates
+  (is (types/date-time? (date-time 2018 8 22 7 12 58)))
+  (is (not (types/local-date-time? (date-time 2018 8 22 7 12 58))))
+  (is (not (types/local-date? (date-time 2018 8 22 7 12 58))))
+
+  (is (not (types/date-time? (local-date-time 2018 8 22 7 12 58))))
+  (is (types/local-date-time? (local-date-time 2018 8 22 7 12 58)))
+  (is (not (types/local-date? (local-date-time 2018 8 22 7 12 58))))
+
+  (is (not (types/date-time? (local-date 2018 8 22))))
+  (is (not (types/local-date-time? (local-date 2018 8 22))))
+  (is (types/local-date? (local-date 2018 8 22))))
+
+

--- a/test_clj_1.9/clj_time/spec_test.clj
+++ b/test_clj_1.9/clj_time/spec_test.clj
@@ -1,0 +1,55 @@
+(ns clj-time.spec-test
+  (:require [clojure.test :refer :all]
+            [clojure.spec :as spec]
+            [clojure.spec.gen :as gen]
+            [clj-time.core :refer :all]
+            [clj-time.spec :as ts]))
+
+(deftest test-predicates
+  (is (ts/utc-date-time? (date-time 2018 8 22 7 12 58)))
+  (is (not (ts/local-date-time? (date-time 2018 8 22 7 12 58))))
+  (is (not (ts/local-date? (date-time 2018 8 22 7 12 58))))
+
+  (is (not (ts/utc-date-time? (local-date-time 2018 8 22 7 12 58))))
+  (is (ts/local-date-time? (local-date-time 2018 8 22 7 12 58)))
+  (is (not (ts/local-date? (local-date-time 2018 8 22 7 12 58))))
+
+  (is (not (ts/utc-date-time? (local-date 2018 8 22))))
+  (is (not (ts/local-date-time? (local-date 2018 8 22))))
+  (is (ts/local-date? (local-date 2018 8 22))))
+
+(deftest test-spec-defs
+  (is (spec/valid? ::ts/utc-date-time (date-time 2018 8 22 7 12 58)))
+  (is (not (spec/valid? ::ts/local-date-time (date-time 2018 8 22 7 12 58))))
+  (is (not (spec/valid? ::ts/local-date (date-time 2018 8 22 7 12 58))))
+
+  (is (not (spec/valid? ::ts/utc-date-time (local-date-time 2018 8 22 7 12 58))))
+  (is (spec/valid? ::ts/local-date-time (local-date-time 2018 8 22 7 12 58)))
+  (is (not (spec/valid? ::ts/local-date (local-date-time 2018 8 22 7 12 58))))
+
+  (is (not (spec/valid? ::ts/utc-date-time (local-date 2018 8 22))))
+  (is (not (spec/valid? ::ts/local-date-time (local-date 2018 8 22))))
+  (is (spec/valid? ::ts/local-date (local-date 2018 8 22))))
+
+(deftest test-generators
+  (is (every? ts/utc-date-time? (gen/sample (spec/gen ::ts/utc-date-time))))
+  (is (every? ts/local-date-time? (gen/sample (spec/gen ::ts/local-date-time))))
+  (is (every? ts/local-date? (gen/sample (spec/gen ::ts/local-date))))
+
+  (is (every? #(and (before? % (date-time 2031 1 1))
+                    (before? (date-time 2010 12 31) %))
+              (gen/sample (spec/gen ::ts/utc-date-time)))))
+
+
+(deftest test-period-generators
+  ; These generators are meant to be used with the ts/*period* dynamic var.
+  ; See test-generator-with-custom-period
+  (is (every? int? (gen/sample (spec/gen ::ts/past))))
+  (is (every? int? (gen/sample (spec/gen ::ts/past-and-future))))
+  (is (every? int? (gen/sample (spec/gen ::ts/future)))))
+
+(deftest test-generator-with-custom-period
+  (binding [ts/*period* #(spec/gen ::ts/past)]
+    (is (every? #(and (before? % (date-time 2011 1 1))
+                      (before? (date-time 2000 12 31) %))
+                (gen/sample (spec/gen ::ts/utc-date-time))))))

--- a/test_clj_1.9/clj_time/spec_test.clj
+++ b/test_clj_1.9/clj_time/spec_test.clj
@@ -3,42 +3,30 @@
             [clojure.spec :as spec]
             [clojure.spec.gen :as gen]
             [clj-time.core :refer :all]
+            [clj-time.types :as types]
             [clj-time.spec :as ts]))
 
-(deftest test-predicates
-  (is (ts/utc-date-time? (date-time 2018 8 22 7 12 58)))
-  (is (not (ts/local-date-time? (date-time 2018 8 22 7 12 58))))
-  (is (not (ts/local-date? (date-time 2018 8 22 7 12 58))))
-
-  (is (not (ts/utc-date-time? (local-date-time 2018 8 22 7 12 58))))
-  (is (ts/local-date-time? (local-date-time 2018 8 22 7 12 58)))
-  (is (not (ts/local-date? (local-date-time 2018 8 22 7 12 58))))
-
-  (is (not (ts/utc-date-time? (local-date 2018 8 22))))
-  (is (not (ts/local-date-time? (local-date 2018 8 22))))
-  (is (ts/local-date? (local-date 2018 8 22))))
-
 (deftest test-spec-defs
-  (is (spec/valid? ::ts/utc-date-time (date-time 2018 8 22 7 12 58)))
+  (is (spec/valid? ::ts/date-time (date-time 2018 8 22 7 12 58)))
   (is (not (spec/valid? ::ts/local-date-time (date-time 2018 8 22 7 12 58))))
   (is (not (spec/valid? ::ts/local-date (date-time 2018 8 22 7 12 58))))
 
-  (is (not (spec/valid? ::ts/utc-date-time (local-date-time 2018 8 22 7 12 58))))
+  (is (not (spec/valid? ::ts/date-time (local-date-time 2018 8 22 7 12 58))))
   (is (spec/valid? ::ts/local-date-time (local-date-time 2018 8 22 7 12 58)))
   (is (not (spec/valid? ::ts/local-date (local-date-time 2018 8 22 7 12 58))))
 
-  (is (not (spec/valid? ::ts/utc-date-time (local-date 2018 8 22))))
+  (is (not (spec/valid? ::ts/date-time (local-date 2018 8 22))))
   (is (not (spec/valid? ::ts/local-date-time (local-date 2018 8 22))))
   (is (spec/valid? ::ts/local-date (local-date 2018 8 22))))
 
 (deftest test-generators
-  (is (every? ts/utc-date-time? (gen/sample (spec/gen ::ts/utc-date-time))))
-  (is (every? ts/local-date-time? (gen/sample (spec/gen ::ts/local-date-time))))
-  (is (every? ts/local-date? (gen/sample (spec/gen ::ts/local-date))))
+  (is (every? types/date-time? (gen/sample (spec/gen ::ts/date-time))))
+  (is (every? types/local-date-time? (gen/sample (spec/gen ::ts/local-date-time))))
+  (is (every? types/local-date? (gen/sample (spec/gen ::ts/local-date))))
 
   (is (every? #(and (before? % (date-time 2031 1 1))
                     (before? (date-time 2010 12 31) %))
-              (gen/sample (spec/gen ::ts/utc-date-time)))))
+              (gen/sample (spec/gen ::ts/date-time)))))
 
 
 (deftest test-period-generators
@@ -52,4 +40,4 @@
   (binding [ts/*period* #(spec/gen ::ts/past)]
     (is (every? #(and (before? % (date-time 2011 1 1))
                       (before? (date-time 2000 12 31) %))
-                (gen/sample (spec/gen ::ts/utc-date-time))))))
+                (gen/sample (spec/gen ::ts/date-time))))))


### PR DESCRIPTION
This addresses issue #220.

I thought it would be useful to define generators to go with the predicates. Since everyone's requirements are probably different for generated dates, I put the actual generator for the range in milliseconds in a dynamic function called `*period*`, which I tried to set up with somewhat sensible defaults.

I was unable to cause the date-time generator to use time zones in the way I expected them to work, but I'm not certain if that's important. If it is I hope someone will be able to fix it. I don't see it as a serious issue if it is not fixed, or if the entire time zone related stuff is scrapped.

The dynamic generators are in functions because when they are evaluated the test.check dependency is triggered. Just like with clojure.spec, the namespace can still be used without the test.check dependency being present, but in that case the generators will not work.

I hope you find this useful.

Thanks,
Darrick