### PR TITLE
On travis Add .m2 dir in cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: clojure
+cache:
+  directories:
+  - $HOME/.m2
 before_script:
   - rm -f test/readme.clj
   - echo y | sudo lein upgrade


### PR DESCRIPTION
Add .m2 directory in cache on travis.
This will result in builds running faster.