### PR TITLE
Exposing week-year field

### DIFF
--- a/src/clj_time/core.clj
+++ b/src/clj_time/core.clj
@@ -119,7 +119,8 @@
     "Returns a new date/time corresponding to the given date/time moved backwards by the given Period(s).")
   (first-day-of-the-month- [this] "Returns the first day of the month")
   (last-day-of-the-month- [this] "Returns the last day of the month")
-  (week-number-of-year [this] "Returs the number of weeks in the year"))
+  (week-number-of-year [this] "Returs the number of weeks in the year")
+  (week-year [this] "Returns the the week based year of the given date/time."))
 
 (defprotocol InTimeUnitProtocol
   "Interface for in-<time unit> functions"
@@ -157,6 +158,7 @@
      (.. ^DateTime this dayOfMonth withMaximumValue))
   (week-number-of-year [this]
     (.getWeekOfWeekyear this))
+  (week-year [this] (.getWeekyear this))
 
   org.joda.time.DateMidnight
   (year [this] (.getYear this))
@@ -182,6 +184,7 @@
      (.. ^DateMidnight this dayOfMonth withMaximumValue))
   (week-number-of-year [this]
     (.getWeekOfWeekyear this))
+  (week-year [this] (.getWeekyear this))
 
   org.joda.time.LocalDateTime
   (year [this] (.getYear this))
@@ -207,6 +210,7 @@
      (.. ^LocalDateTime this dayOfMonth withMaximumValue))
   (week-number-of-year [this]
     (.getWeekOfWeekyear this))
+  (week-year [this] (.getWeekyear this))
 
   org.joda.time.YearMonth
   (year [this] (.getYear this))
@@ -233,6 +237,7 @@
      (.. ^LocalDate this dayOfMonth withMaximumValue))
   (week-number-of-year [this]
     (.getWeekOfWeekyear this))
+  (week-year [this] (.getWeekyear this))
 
   org.joda.time.LocalTime
   (hour [this] (.getHourOfDay this))

--- a/src/clj_time/core.clj
+++ b/src/clj_time/core.clj
@@ -119,7 +119,7 @@
     "Returns a new date/time corresponding to the given date/time moved backwards by the given Period(s).")
   (first-day-of-the-month- [this] "Returns the first day of the month")
   (last-day-of-the-month- [this] "Returns the last day of the month")
-  (week-number-of-year [this] "Returs the number of weeks in the year")
+  (week-number-of-year [this] "Returns the week of the week based year of the given date/time")
   (week-year [this] "Returns the the week based year of the given date/time."))
 
 (defprotocol InTimeUnitProtocol

--- a/test/clj_time/core_test.clj
+++ b/test/clj_time/core_test.clj
@@ -592,6 +592,12 @@
   (is (= 1 (week-number-of-year (date-time 2012 12 31))))
   (is (= 1 (week-number-of-year (date-time 2013 1 1)))))
 
+(deftest test-week-year
+  (is (= 2015 (week-year (date-time 2016 1 3))))
+  (is (= 2016 (week-year (date-time 2016 1 4))))
+  (is (= 2016 (week-year (date-time 2017 1 1))))
+  (is (= 2017 (week-year (date-time 2017 1 2)))))
+
 (deftest test-number-of-days-in-the-month
   (is (= 31 (number-of-days-in-the-month 2012 1)))
   (is (= 31 (number-of-days-in-the-month (date-time 2012 1 3))))


### PR DESCRIPTION
Closes #239

Open to suggestions to what to call this thing. Think [ISO 8601](iso-weekyear) calls it a "week year", and the corresponding week "week number".

[iso-weekyear]: https://en.wikipedia.org/wiki/ISO_week_date
 