### PR TITLE
Extend Inst to org.joda.time.ReadableInstant on Clojure 1.9

### DIFF
--- a/src/clj_time/core.clj
+++ b/src/clj_time/core.clj
@@ -781,3 +781,13 @@
   				(concat (take-while (partial not= dt-fn) dt-fns) [dt-fn])
   				(repeat [dt])))
       tz))))
+
+(defmacro ^:private when-available [sym & body]
+  (when (resolve sym)
+    `(do ~@body)))
+
+(when-available Inst
+  (extend-protocol Inst
+    org.joda.time.ReadableInstant
+    (inst-ms* [inst]
+      (.getMillis inst))))

--- a/test_clj_1.9/clj_time/inst_test.clj
+++ b/test_clj_1.9/clj_time/inst_test.clj
@@ -1,0 +1,10 @@
+(ns clj-time.inst-test
+  (:refer-clojure :exclude [extend second])
+  (:require [clojure.test :refer :all]
+            [clj-time.core :refer :all])
+  (:import org.joda.time.DateTime))
+
+(deftest test-inst
+  (let [^DateTime n (now)]
+    (is (inst? n))
+    (is (= (inst-ms n) (.getMillis n)))))


### PR DESCRIPTION
The change proposed here extends the `Inst` protocol to `org.joda.time.ReadableInstant` when `clj-time.core` is loaded. Since `Inst` was only added in Clojure 1.9, the extension is conditional on availability of `Inst`.

This should resolve #248.

Notes about the changes:

* Of all the Joda-Time API classes the interface `org.joda.time.ReadableInstant` (which is implemented by `org.joda.time.DateTime`) seems best suited for extension to `Inst`.
* I renamed the Leiningen profile `:spec` to `:1.9` to better reflect what’s in the tests (not just spec).

This changeset seems reasonable to me but of course I am happy to incorporate any feedback you might have.
