### PR TITLE
Convert to local datetime during timezone conversion

### DIFF
--- a/src/clj_time/core.clj
+++ b/src/clj_time/core.clj
@@ -419,7 +419,10 @@
    the given ReadableDateTime, but with calendar fields corresponding to the given
    TimeZone."
   [^DateTime dt ^DateTimeZone tz]
-  (.withZone dt tz))
+  (-> dt
+      (.withZone tz)
+      .toLocalDateTime
+      (.toDateTime tz)))
 
 (defn ^org.joda.time.DateTime
   from-time-zone
@@ -427,7 +430,10 @@
    the given ReadableDateTime, but for a correspondingly different absolute instant in
    time."
   [^DateTime dt ^DateTimeZone tz]
-  (.withZoneRetainFields dt tz))
+  (-> dt
+      (.withZoneRetainFields tz)
+      .toLocalDateTime
+      (.toDateTime tz)))
 
 (defn years
   "Given a number, returns a Period representing that many years.
@@ -774,12 +780,12 @@
   ([^DateTime dt dt-fn]
    (let [dt-fns [year month day hour minute second milli]
          tz (.getZone dt)]
-    (.withZoneRetainFields
-                ^DateTime
-  	 	(apply date-time
-  	 		(map apply
-  				(concat (take-while (partial not= dt-fn) dt-fns) [dt-fn])
-  				(repeat [dt])))
+     (.withZoneRetainFields
+      ^DateTime
+      (apply date-time
+             (map apply
+                  (concat (take-while (partial not= dt-fn) dt-fns) [dt-fn])
+                  (repeat [dt])))
       tz))))
 
 (defmacro ^:private when-available [sym & body]


### PR DESCRIPTION
When we convert a DateTime to another timezone, there could be a case
that the daylight savings starts or ends during the course of that
day. In this case, the changed daylight savings time should apply only
after that point in the day. This is achieved by converting the
date-time object to a local-date-time object and then converting it
back to a date-time-object.

For example, in Asia/Amman, daylight savings ends on 26 Oct at 1 am,
and the timezone offset becomes +03:00 from +02:00.
;; Older behaviour:
(let [dtz ^DateTimeZone (clj-time.core/time-zone-for-id "Asia/Amman")]
  (-> (clj-time.core/date-time 2018 3 26)
      (clj-time.core/from-time-zone dtz) str))
;; => 2018-10-26T00:00:00.000+02:00

The above should not be in the +02:00 timezone, but in the +03:00
timezone
;; Altered behaviour:
(let [dtz ^DateTimeZone (clj-time.core/time-zone-for-id "Asia/Amman")]
  (-> (clj-time.core/date-time 2018 10 26)
      (clj-time.core/from-time-zone dtz)))
;; => 2018-10-26T00:00:00.000+03:00