### PR TITLE
Make project status more prominent in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@
 
 # clj-time
 
-A date and time library for Clojure, wrapping the [Joda Time](http://www.joda.org/joda-time/) library. **The Joda Time website says:**
+A date and time library for Clojure, wrapping the [Joda Time](http://www.joda.org/joda-time/) library.
+
+## Project Status
+
+**The Joda Time website says:**
 
 > Note that from Java SE 8 onwards, users are asked to migrate to java.time (JSR-310) - a core part of the JDK which replaces this project.
 


### PR DESCRIPTION
It was just a little too easy to miss this important info; some questions
were asked today in Clojurians that might not have been necessary had
this info already been more prominent.